### PR TITLE
feat(z-image): add sigma schedules, aspect ratios, saveinfo, shift, MCF sampler;

### DIFF
--- a/src/mflux/cli/parser/parsers.py
+++ b/src/mflux/cli/parser/parsers.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import math
 import random
 import sys
 import time
@@ -10,6 +11,24 @@ from mflux.cli.defaults import defaults as ui_defaults
 from mflux.models.common.resolution.lora_resolution import LoraResolution
 from mflux.models.flux.variants.in_context.utils.in_context_loras import LORA_NAME_MAP
 from mflux.utils import box_values, scale_factor
+
+ASPECT_RATIOS = {
+    "1:1":  (1, 1),
+    "4:3":  (4, 3),
+    "3:4":  (3, 4),
+    "3:2":  (3, 2),
+    "2:3":  (2, 3),
+    "16:9": (16, 9),
+    "9:16": (9, 16),
+    "18:9": (18, 9),
+    "9:18": (9, 18),
+    "21:9": (21, 9),
+    "9:21": (9, 21),
+}
+
+
+def _ceil16(value):
+    return math.ceil(value / 16) * 16
 
 
 class ModelSpecAction(argparse.Action):
@@ -117,6 +136,13 @@ class CommandLineParser(argparse.ArgumentParser):
         self.add_argument("--seed", type=int, default=None, nargs='+', help="Specify 1+ Entropy Seeds (Default is 1 time-based random-seed)")
         self.add_argument("--auto-seeds", type=int, default=-1, help="Auto generate N Entropy Seeds (random ints between 0 and 1 billion")
         self.add_argument("--scheduler", type=str, default="linear", help="Choose from implemented schedulers (linear only for now). Or bring your own: 'your_package.some_module.FooScheduler'")
+        self.add_argument("--shift", type=float, default=None, help="Override the automatic sigma shift (mu) value. By default, mu is computed from image dimensions. Higher values push the noise schedule towards higher noise levels.")
+        self.add_argument("--mcf-max-change", type=float, default=None, help="MCF (Mean Change Factor) sampler: maximum allowed mean absolute change per denoising step. If a step's change exceeds this threshold, it is scaled down. Typical values: 0.05-0.50. Default: disabled.")
+        sigma_group = self.add_mutually_exclusive_group()
+        sigma_group.add_argument("--cosine", action="store_true", help="Use smooth cosine sigma schedule: S-curve that allocates more steps at high/low noise")
+        sigma_group.add_argument("--karras", action="store_true", help="Use Karras sigma schedule (concentrates steps toward the end of denoising for finer details)")
+        sigma_group.add_argument("--exponential", action="store_true", help="Use exponential sigma schedule (logarithmic spacing between sigma_max and sigma_min)")
+        self.add_argument("--aspect", type=str, default=None, choices=list(ASPECT_RATIOS.keys()), help="Aspect ratio preset (e.g. 16:9, 3:2). If combined with only --width or --height, the other is auto-computed.")
         self._add_image_generator_common_arguments(supports_dimension_scale_factor=supports_dimension_scale_factor)
         if supports_metadata_config:
             self.add_metadata_config()
@@ -166,7 +192,7 @@ class CommandLineParser(argparse.ArgumentParser):
         self.add_argument("--redux-image-strengths", type=float, nargs="*", default=None, help="Strength values (between 0.0 and 1.0) for each reference image. Default is 1.0 for all images.")
 
     def add_output_arguments(self) -> None:
-        self.add_argument("--metadata", action="store_true", help="Export image metadata as a JSON file.")
+        self.add_argument("--saveinfo", action="store_true", help="Save with descriptive filename: Timestamp_Seed_S{Steps}_{LoRA}_{Scheduler}_{SigmaArgs}.png")
         self.add_argument("--output", type=str, default="image.png", help="The filename for the output image. Default is \"image.png\".")
         self.add_argument('--stepwise-image-output-dir', type=str, default=None, help='[EXPERIMENTAL] Output dir to write step-wise images and their final composite image to. This feature may change in future versions.')
 
@@ -387,5 +413,35 @@ class CommandLineParser(argparse.ArgumentParser):
             namespace.model_path = None if namespace.model in ui_defaults.MODEL_CHOICES else namespace.model
         else:
             namespace.model_path = None
+
+        # Resolve sigma_schedule from mutually exclusive flags
+        if self.supports_image_generation:
+            if getattr(namespace, "cosine", False):
+                namespace.sigma_schedule = "cosine"
+            elif getattr(namespace, "karras", False):
+                namespace.sigma_schedule = "karras"
+            elif getattr(namespace, "exponential", False):
+                namespace.sigma_schedule = "exponential"
+            else:
+                namespace.sigma_schedule = "linear"
+
+        # Resolve --aspect ratio with auto-dimension computation
+        if self.supports_image_generation and getattr(namespace, "aspect", None) is not None:
+            w_ratio, h_ratio = ASPECT_RATIOS[namespace.aspect]
+            ratio = w_ratio / h_ratio
+            default_w = self.get_default("width")
+            default_h = self.get_default("height")
+            width_explicit = (namespace.width != default_w) if not isinstance(namespace.width, scale_factor.ScaleFactor) else False
+            height_explicit = (namespace.height != default_h) if not isinstance(namespace.height, scale_factor.ScaleFactor) else False
+            target_pixels = ui_defaults.WIDTH * ui_defaults.HEIGHT
+            if width_explicit and not height_explicit:
+                namespace.height = _ceil16(namespace.width / ratio)
+            elif height_explicit and not width_explicit:
+                namespace.width = _ceil16(namespace.height * ratio)
+            elif not width_explicit and not height_explicit:
+                h = (target_pixels / ratio) ** 0.5
+                w = h * ratio
+                namespace.width = _ceil16(w)
+                namespace.height = _ceil16(h)
 
         return namespace

--- a/src/mflux/cli/parser/parsers.py
+++ b/src/mflux/cli/parser/parsers.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import math
 import random
 import sys
 import time
@@ -10,6 +11,24 @@ from mflux.cli.defaults import defaults as ui_defaults
 from mflux.models.common.resolution.lora_resolution import LoraResolution
 from mflux.models.flux.variants.in_context.utils.in_context_loras import LORA_NAME_MAP
 from mflux.utils import box_values, scale_factor
+
+ASPECT_RATIOS = {
+    "1:1":  (1, 1),
+    "4:3":  (4, 3),
+    "3:4":  (3, 4),
+    "3:2":  (3, 2),
+    "2:3":  (2, 3),
+    "16:9": (16, 9),
+    "9:16": (9, 16),
+    "18:9": (18, 9),
+    "9:18": (9, 18),
+    "21:9": (21, 9),
+    "9:21": (9, 21),
+}
+
+
+def _ceil16(value):
+    return math.ceil(value / 16) * 16
 
 
 class ModelSpecAction(argparse.Action):
@@ -119,6 +138,13 @@ class CommandLineParser(argparse.ArgumentParser):
         self.add_argument("--seed", type=int, default=None, nargs='+', help="Specify 1+ Entropy Seeds (Default is 1 time-based random-seed)")
         self.add_argument("--auto-seeds", type=int, default=-1, help="Auto generate N Entropy Seeds (random ints between 0 and 1 billion")
         self.add_argument("--scheduler", type=str, default="linear", help="Choose from implemented schedulers (linear only for now). Or bring your own: 'your_package.some_module.FooScheduler'")
+        self.add_argument("--shift", type=float, default=None, help="Override the automatic sigma shift (mu) value. By default, mu is computed from image dimensions. Higher values push the noise schedule towards higher noise levels.")
+        self.add_argument("--mcf-max-change", type=float, default=None, help="MCF (Mean Change Factor) sampler: maximum allowed mean absolute change per denoising step. If a step's change exceeds this threshold, it is scaled down. Typical values: 0.05-0.50. Default: disabled.")
+        sigma_group = self.add_mutually_exclusive_group()
+        sigma_group.add_argument("--cosine", action="store_true", help="Use smooth cosine sigma schedule: S-curve that allocates more steps at high/low noise")
+        sigma_group.add_argument("--karras", action="store_true", help="Use Karras sigma schedule (concentrates steps toward the end of denoising for finer details)")
+        sigma_group.add_argument("--exponential", action="store_true", help="Use exponential sigma schedule (logarithmic spacing between sigma_max and sigma_min)")
+        self.add_argument("--aspect", type=str, default=None, choices=list(ASPECT_RATIOS.keys()), help="Aspect ratio preset (e.g. 16:9, 3:2). If combined with only --width or --height, the other is auto-computed.")
         self._add_image_generator_common_arguments(supports_dimension_scale_factor=supports_dimension_scale_factor)
         if supports_metadata_config:
             self.add_metadata_config()
@@ -172,7 +198,7 @@ class CommandLineParser(argparse.ArgumentParser):
         self.add_argument("--redux-image-strengths", type=float, nargs="*", default=None, help="Strength values (between 0.0 and 1.0) for each reference image. Default is 1.0 for all images.")
 
     def add_output_arguments(self) -> None:
-        self.add_argument("--metadata", action="store_true", help="Export image metadata as a JSON file.")
+        self.add_argument("--saveinfo", action="store_true", help="Save with descriptive filename: Timestamp_Seed_S{Steps}_{LoRA}_{Scheduler}_{SigmaArgs}.png")
         self.add_argument("--output", type=str, default="image.png", help="The filename for the output image. Default is \"image.png\".")
         self.add_argument('--stepwise-image-output-dir', type=str, default=None, help='[EXPERIMENTAL] Output dir to write step-wise images and their final composite image to. This feature may change in future versions.')
 
@@ -442,5 +468,35 @@ class CommandLineParser(argparse.ArgumentParser):
             namespace.model_path = None if namespace.model in ui_defaults.MODEL_CHOICES else namespace.model
         else:
             namespace.model_path = None
+
+        # Resolve sigma_schedule from mutually exclusive flags
+        if self.supports_image_generation:
+            if getattr(namespace, "cosine", False):
+                namespace.sigma_schedule = "cosine"
+            elif getattr(namespace, "karras", False):
+                namespace.sigma_schedule = "karras"
+            elif getattr(namespace, "exponential", False):
+                namespace.sigma_schedule = "exponential"
+            else:
+                namespace.sigma_schedule = "linear"
+
+        # Resolve --aspect ratio with auto-dimension computation
+        if self.supports_image_generation and getattr(namespace, "aspect", None) is not None:
+            w_ratio, h_ratio = ASPECT_RATIOS[namespace.aspect]
+            ratio = w_ratio / h_ratio
+            default_w = self.get_default("width")
+            default_h = self.get_default("height")
+            width_explicit = (namespace.width != default_w) if not isinstance(namespace.width, scale_factor.ScaleFactor) else False
+            height_explicit = (namespace.height != default_h) if not isinstance(namespace.height, scale_factor.ScaleFactor) else False
+            target_pixels = ui_defaults.WIDTH * ui_defaults.HEIGHT
+            if width_explicit and not height_explicit:
+                namespace.height = _ceil16(namespace.width / ratio)
+            elif height_explicit and not width_explicit:
+                namespace.width = _ceil16(namespace.height * ratio)
+            elif not width_explicit and not height_explicit:
+                h = (target_pixels / ratio) ** 0.5
+                w = h * ratio
+                namespace.width = _ceil16(w)
+                namespace.height = _ceil16(h)
 
         return namespace

--- a/src/mflux/models/common/config/config.py
+++ b/src/mflux/models/common/config/config.py
@@ -29,6 +29,9 @@ class Config:
         masked_image_path: Path | str | None = None,
         controlnet_strength: float | None = None,
         scheduler: str = "linear",
+        shift: float | None = None,
+        mcf_max_change: float | None = None,
+        sigma_schedule: str = "linear",
     ):
         # Resolve any missing dimension dynamically, using the reference image when available.
         if width is None or height is None:
@@ -56,6 +59,9 @@ class Config:
         self._masked_image_path = Path(masked_image_path) if isinstance(masked_image_path, str) else masked_image_path
         self._controlnet_strength = controlnet_strength
         self._scheduler_str = scheduler
+        self._shift = shift
+        self._mcf_max_change = mcf_max_change
+        self._sigma_schedule = sigma_schedule
         self._scheduler = None
         self._time_steps = None
 
@@ -141,6 +147,18 @@ class Config:
     @property
     def controlnet_strength(self) -> float | None:
         return self._controlnet_strength
+
+    @property
+    def shift(self) -> float | None:
+        return self._shift
+
+    @property
+    def mcf_max_change(self) -> float | None:
+        return self._mcf_max_change
+
+    @property
+    def sigma_schedule(self) -> str:
+        return self._sigma_schedule
 
     @property
     def scheduler(self):

--- a/src/mflux/models/common/schedulers/flow_match_euler_discrete_scheduler.py
+++ b/src/mflux/models/common/schedulers/flow_match_euler_discrete_scheduler.py
@@ -40,8 +40,17 @@ class FlowMatchEulerDiscreteScheduler(BaseScheduler):
         )
 
     def set_mu(self, mu: float) -> None:
+        if self.config.shift is not None:
+            mu = float(self.config.shift)
+            
         num_steps = self.config.num_inference_steps
-        sigmas = mx.linspace(1.0, 1.0 / num_steps, num_steps, dtype=mx.float32)
+        
+        custom_sigmas = FlowMatchEulerDiscreteScheduler._generate_base_sigmas(num_steps, self.config.sigma_schedule)
+        if custom_sigmas is not None:
+            sigmas = mx.array(custom_sigmas, dtype=mx.float32)
+        else:
+            sigmas = mx.linspace(1.0, 1.0 / num_steps, num_steps, dtype=mx.float32)
+            
         sigmas = FlowMatchEulerDiscreteScheduler._time_shift_exponential_array(mu, 1.0, sigmas)
         self._timesteps = sigmas * self.num_train_timesteps
         sigmas = mx.concatenate([sigmas, mx.zeros((1,), dtype=sigmas.dtype)], axis=0)
@@ -58,6 +67,29 @@ class FlowMatchEulerDiscreteScheduler(BaseScheduler):
         m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
         b = base_shift - m * base_seq_len
         return float(m * image_seq_len + b)
+
+    @staticmethod
+    def _generate_base_sigmas(num_steps: int, schedule: str = "linear") -> list[float]:
+        sigma_max = 1.0
+        sigma_min = 1.0 / 1000  # 1/num_train_timesteps
+        if schedule == "cosine":
+            import numpy as np
+            t = np.linspace(0, 1, num_steps)
+            sigmas = (1.0 + np.cos(t * math.pi)) / 2.0
+            return sigmas.tolist()
+        elif schedule == "karras":
+            rho = 7.0
+            ramp = [i / max(num_steps - 1, 1) for i in range(num_steps)]
+            min_inv_rho = sigma_min ** (1.0 / rho)
+            max_inv_rho = sigma_max ** (1.0 / rho)
+            return [(max_inv_rho + r * (min_inv_rho - max_inv_rho)) ** rho for r in ramp]
+        elif schedule == "exponential":
+            log_max = math.log(sigma_max)
+            log_min = math.log(sigma_min)
+            return [math.exp(log_max + i * (log_min - log_max) / max(num_steps - 1, 1)) for i in range(num_steps)]
+        else:
+            # linear (original behavior)
+            return None  # signal to use original logic
 
     @staticmethod
     def get_timesteps_and_sigmas(
@@ -89,11 +121,14 @@ class FlowMatchEulerDiscreteScheduler(BaseScheduler):
 
     @staticmethod
     def _time_shift_exponential(mu: float, sigma_power: float, t: float) -> float:
+        if t <= 0.0:
+            return 0.0
         return math.exp(mu) / (math.exp(mu) + ((1.0 / t - 1.0) ** sigma_power))
 
     @staticmethod
     def _time_shift_exponential_array(mu: float, sigma_power: float, t: mx.array) -> mx.array:
-        return mx.exp(mu) / (mx.exp(mu) + ((1.0 / t - 1.0) ** sigma_power))
+        safe_t = mx.clip(t, 1e-12, None)
+        return mx.exp(mu) / (mx.exp(mu) + ((1.0 / safe_t - 1.0) ** sigma_power))
 
     def _stretch_to_terminal(self, sigmas: list[float]) -> list[float]:
         one_minus_sigmas = [1.0 - s for s in sigmas]
@@ -105,12 +140,17 @@ class FlowMatchEulerDiscreteScheduler(BaseScheduler):
         num_steps = self.config.num_inference_steps
         sigma_min = 1.0 / self.num_train_timesteps
         sigma_max = 1.0
-        timesteps_linear = [
-            sigma_max * self.num_train_timesteps
-            - i * (sigma_max - sigma_min) * self.num_train_timesteps / (num_steps - 1)
-            for i in range(num_steps)
-        ]
-        sigmas_linear = [t / self.num_train_timesteps for t in timesteps_linear]
+        schedule = self.config.sigma_schedule
+        custom_sigmas = FlowMatchEulerDiscreteScheduler._generate_base_sigmas(num_steps, schedule)
+        if custom_sigmas is not None:
+            sigmas_linear = custom_sigmas
+        else:
+            timesteps_linear = [
+                sigma_max * self.num_train_timesteps
+                - i * (sigma_max - sigma_min) * self.num_train_timesteps / (num_steps - 1)
+                for i in range(num_steps)
+            ]
+            sigmas_linear = [t / self.num_train_timesteps for t in timesteps_linear]
         sigmas_shifted = [FlowMatchEulerDiscreteScheduler._time_shift_exponential(1.0, 1.0, s) for s in sigmas_linear]
         sigmas_final = self._stretch_to_terminal(sigmas_shifted)
         timesteps = [s * self.num_train_timesteps for s in sigmas_final]

--- a/src/mflux/models/common/schedulers/linear_scheduler.py
+++ b/src/mflux/models/common/schedulers/linear_scheduler.py
@@ -1,3 +1,4 @@
+import math
 from typing import TYPE_CHECKING
 
 import mlx.core as mx
@@ -22,11 +23,28 @@ class LinearScheduler(BaseScheduler):
     def timesteps(self) -> mx.array:
         return self._timesteps
 
+    @staticmethod
+    def _generate_base_sigmas(num_steps: int, schedule: str = "linear") -> mx.array:
+        sigma_max = 1.0
+        sigma_min = 1.0 / num_steps
+        if schedule == "cosine":
+            t = mx.linspace(0, 1, num_steps)
+            sigmas = (1.0 + mx.cos(t * math.pi)) / 2.0
+        elif schedule == "karras":
+            rho = 7.0
+            ramp = mx.linspace(0, 1, num_steps)
+            min_inv_rho = sigma_min ** (1.0 / rho)
+            max_inv_rho = sigma_max ** (1.0 / rho)
+            sigmas = (max_inv_rho + ramp * (min_inv_rho - max_inv_rho)) ** rho
+        elif schedule == "exponential":
+            sigmas = mx.exp(mx.linspace(math.log(sigma_max), math.log(sigma_min), num_steps))
+        else:
+            sigmas = mx.linspace(sigma_max, sigma_min, num_steps)
+        return sigmas.astype(mx.float32)
+
     def _get_sigmas(self) -> mx.array:
         model_config = self.config.model_config
-        num_steps = self.config.num_inference_steps
-        sigmas = mx.linspace(1.0, 1.0 / num_steps, num_steps)
-        sigmas = mx.array(sigmas).astype(mx.float32)
+        sigmas = self._generate_base_sigmas(self.config.num_inference_steps, self.config.sigma_schedule)
         sigmas = mx.concatenate([sigmas, mx.zeros(1)])
         if model_config.requires_sigma_shift:
             m = (model_config.sigma_max_shift - model_config.sigma_base_shift) / (
@@ -34,6 +52,8 @@ class LinearScheduler(BaseScheduler):
             )
             b = model_config.sigma_base_shift - m * model_config.sigma_base_seq_len
             mu = m * self.config.width * self.config.height / 256 + b
+            if self.config.shift is not None:
+                mu = self.config.shift
             mu = mx.array(mu)
 
             shifted = mx.exp(mu) / (mx.exp(mu) + (1 / sigmas[:-1] - 1))

--- a/src/mflux/models/fibo/cli/fibo_generate.py
+++ b/src/mflux/models/fibo/cli/fibo_generate.py
@@ -76,7 +76,7 @@ def main():
             )
 
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux/cli/flux_concept.py
+++ b/src/mflux/models/flux/cli/flux_concept.py
@@ -57,7 +57,7 @@ def main():
                 heatmap_layer_indices=args.heatmap_layer_indices,
             )
             # 4. Save the image and heatmap
-            image.save_with_heatmap(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save_with_heatmap(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux/cli/flux_concept_from_image.py
+++ b/src/mflux/models/flux/cli/flux_concept_from_image.py
@@ -56,7 +56,7 @@ def main():
                 heatmap_layer_indices=args.heatmap_layer_indices,
             )
             # 4. Save the image and heatmap
-            image.save_with_heatmap(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save_with_heatmap(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux/cli/flux_generate.py
+++ b/src/mflux/models/flux/cli/flux_generate.py
@@ -63,7 +63,7 @@ def main():
                 negative_prompt=PromptUtil.read_negative_prompt(args),
             )
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux/cli/flux_generate.py
+++ b/src/mflux/models/flux/cli/flux_generate.py
@@ -66,7 +66,7 @@ def main():
                 negative_prompt=PromptUtil.read_negative_prompt(args),
             )
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux/cli/flux_generate_controlnet.py
+++ b/src/mflux/models/flux/cli/flux_generate_controlnet.py
@@ -56,7 +56,7 @@ def main():
             )
 
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux/cli/flux_generate_depth.py
+++ b/src/mflux/models/flux/cli/flux_generate_depth.py
@@ -54,7 +54,7 @@ def main():
             )
 
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux/cli/flux_generate_fill.py
+++ b/src/mflux/models/flux/cli/flux_generate_fill.py
@@ -53,7 +53,7 @@ def main():
             )
 
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux/cli/flux_generate_in_context_catvton.py
+++ b/src/mflux/models/flux/cli/flux_generate_in_context_catvton.py
@@ -64,7 +64,7 @@ def main():
 
             # 4. Save the image(s)
             output_path = Path(args.output.format(seed=seed))
-            image.get_right_half().save(path=output_path, export_json_metadata=args.metadata)
+            image.get_right_half().save(path=output_path)
             if args.save_full_image:
                 image.save(path=output_path.with_stem(output_path.stem + "_full"))
 

--- a/src/mflux/models/flux/cli/flux_generate_in_context_dev.py
+++ b/src/mflux/models/flux/cli/flux_generate_in_context_dev.py
@@ -68,7 +68,7 @@ def main():
             )
             # 4. Save the image
             output_path = Path(args.output.format(seed=seed))
-            image.get_right_half().save(path=output_path, export_json_metadata=args.metadata)
+            image.get_right_half().save(path=output_path)
             if args.save_full_image:
                 image.save(path=output_path.with_stem(output_path.stem + "_full"))
 

--- a/src/mflux/models/flux/cli/flux_generate_in_context_edit.py
+++ b/src/mflux/models/flux/cli/flux_generate_in_context_edit.py
@@ -70,7 +70,7 @@ def main():
 
             # 4. Save the image(s)
             output_path = Path(args.output.format(seed=seed))
-            image.get_right_half().save(path=output_path, export_json_metadata=args.metadata)
+            image.get_right_half().save(path=output_path)
             if args.save_full_image:
                 image.save(path=output_path.with_stem(output_path.stem + "_full"))
 

--- a/src/mflux/models/flux/cli/flux_generate_kontext.py
+++ b/src/mflux/models/flux/cli/flux_generate_kontext.py
@@ -63,7 +63,7 @@ def main():
 
             # 4. Save the image
             output_path = Path(args.output.format(seed=seed))
-            image.save(path=output_path, export_json_metadata=args.metadata)
+            image.save(path=output_path)
 
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)

--- a/src/mflux/models/flux/cli/flux_generate_redux.py
+++ b/src/mflux/models/flux/cli/flux_generate_redux.py
@@ -62,7 +62,7 @@ def main():
             )
 
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux/cli/flux_upscale.py
+++ b/src/mflux/models/flux/cli/flux_upscale.py
@@ -56,7 +56,7 @@ def main():
             )
 
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux2/cli/flux2_edit_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_edit_generate.py
@@ -72,7 +72,6 @@ def main():
             ImageUtil.save_image(
                 image=image,
                 path=args.output.format(seed=seed),
-                export_json_metadata=args.metadata,
             )
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)

--- a/src/mflux/models/flux2/cli/flux2_edit_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_edit_generate.py
@@ -76,7 +76,6 @@ def main():
             ImageUtil.save_image(
                 image=image,
                 path=args.output.format(seed=seed),
-                export_json_metadata=args.metadata,
             )
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)

--- a/src/mflux/models/flux2/cli/flux2_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_generate.py
@@ -68,7 +68,6 @@ def main():
             ImageUtil.save_image(
                 image=image,
                 path=args.output.format(seed=seed),
-                export_json_metadata=args.metadata,
             )
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)

--- a/src/mflux/models/qwen/cli/qwen_image_edit_generate.py
+++ b/src/mflux/models/qwen/cli/qwen_image_edit_generate.py
@@ -59,7 +59,7 @@ def main():
 
             # 5. Save the image
             output_path = Path(args.output.format(seed=seed))
-            image.save(path=output_path, export_json_metadata=args.metadata)
+            image.save(path=output_path)
 
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)

--- a/src/mflux/models/qwen/cli/qwen_image_generate.py
+++ b/src/mflux/models/qwen/cli/qwen_image_generate.py
@@ -61,7 +61,7 @@ def main():
                 image_strength=args.image_strength,
             )
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            image.save(path=args.output.format(seed=seed))
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/z_image/cli/z_image_generate.py
+++ b/src/mflux/models/z_image/cli/z_image_generate.py
@@ -1,4 +1,6 @@
 import sys
+from datetime import datetime
+from pathlib import Path
 
 from mflux.callbacks.callback_manager import CallbackManager
 from mflux.cli.parser.parsers import CommandLineParser
@@ -10,13 +12,47 @@ from mflux.utils.exceptions import PromptFileReadError, StopImageGenerationExcep
 from mflux.utils.prompt_util import PromptUtil
 
 
+def _nodot(val):
+    s = f"{val:g}"
+    return s.replace(".", "") if "." in s else s + "0"
+
+
+def _build_saveinfo_filename(args, seed):
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    sched_tag = getattr(args, "scheduler", "linear")
+    sa_parts = []
+    if getattr(args, "cosine", False):
+        sa_parts.append("cos")
+    if getattr(args, "karras", False):
+        sa_parts.append("karras")
+    if getattr(args, "exponential", False):
+        sa_parts.append("exp")
+    if getattr(args, "shift", None) is not None:
+        sa_parts.append(f"shift_{_nodot(args.shift)}")
+    if getattr(args, "mcf_max_change", None) is not None:
+        sa_parts.append(f"mcf_{_nodot(args.mcf_max_change)}")
+    sa = "_".join(sa_parts)
+    lora_tag = "NoLora"
+    if getattr(args, "lora_paths", None):
+        names = [Path(p).stem for p in args.lora_paths]
+        lora_tag = "+".join(names)
+        if getattr(args, "lora_scales", None):
+            sc = "+".join(_nodot(s) for s in args.lora_scales)
+            lora_tag = f"{lora_tag}-{sc}"
+    parts = [timestamp, str(seed), f"S{args.steps}", lora_tag, sched_tag]
+    if sa:
+        parts.append(sa)
+    output_dir = str(Path(args.output).parent)
+    return str(Path(output_dir) / ("_".join(parts) + ".png"))
+
+
 def main():
     # 0. Parse command line arguments
     parser = CommandLineParser(description="Generate an image using Z-Image.")
     parser.add_general_arguments()
     parser.add_model_arguments(require_model_arg=False)
     parser.add_lora_arguments()
-    parser.add_image_generator_arguments(supports_metadata_config=True)
+    parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
     parser.add_image_to_image_arguments()
     parser.add_output_arguments()
     args = parser.parse_args()
@@ -64,9 +100,13 @@ def main():
                 image_strength=args.image_strength,
                 scheduler=args.scheduler,
                 negative_prompt=args.negative_prompt,
+                shift=args.shift,
+                mcf_max_change=args.mcf_max_change,
+                sigma_schedule=args.sigma_schedule,
             )
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            output_path = _build_saveinfo_filename(args, seed) if args.saveinfo else args.output.format(seed=seed)
+            image.save(path=output_path)
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/z_image/cli/z_image_turbo_generate.py
+++ b/src/mflux/models/z_image/cli/z_image_turbo_generate.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from pathlib import Path
+
 from mflux.callbacks.callback_manager import CallbackManager
 from mflux.cli.parser.parsers import CommandLineParser
 from mflux.models.common.config import ModelConfig
@@ -6,6 +9,40 @@ from mflux.models.z_image.variants.z_image import ZImage
 from mflux.utils.dimension_resolver import DimensionResolver
 from mflux.utils.exceptions import PromptFileReadError, StopImageGenerationException
 from mflux.utils.prompt_util import PromptUtil
+
+
+def _nodot(val):
+    s = f"{val:g}"
+    return s.replace(".", "") if "." in s else s + "0"
+
+
+def _build_saveinfo_filename(args, seed):
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    sched_tag = getattr(args, "scheduler", "linear")
+    sa_parts = []
+    if getattr(args, "cosine", False):
+        sa_parts.append("cos")
+    if getattr(args, "karras", False):
+        sa_parts.append("karras")
+    if getattr(args, "exponential", False):
+        sa_parts.append("exp")
+    if getattr(args, "shift", None) is not None:
+        sa_parts.append(f"shift_{_nodot(args.shift)}")
+    if getattr(args, "mcf_max_change", None) is not None:
+        sa_parts.append(f"mcf_{_nodot(args.mcf_max_change)}")
+    sa = "_".join(sa_parts)
+    lora_tag = "NoLora"
+    if getattr(args, "lora_paths", None):
+        names = [Path(p).stem for p in args.lora_paths]
+        lora_tag = "+".join(names)
+        if getattr(args, "lora_scales", None):
+            sc = "+".join(_nodot(s) for s in args.lora_scales)
+            lora_tag = f"{lora_tag}-{sc}"
+    parts = [timestamp, str(seed), f"S{args.steps}", lora_tag, sched_tag]
+    if sa:
+        parts.append(sa)
+    output_dir = str(Path(args.output).parent)
+    return str(Path(output_dir) / ("_".join(parts) + ".png"))
 
 
 def main():
@@ -56,9 +93,13 @@ def main():
                 image_strength=args.image_strength,
                 scheduler=args.scheduler,
                 negative_prompt=args.negative_prompt,
+                shift=args.shift,
+                mcf_max_change=args.mcf_max_change,
+                sigma_schedule=args.sigma_schedule,
             )
             # 4. Save the image
-            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+            output_path = _build_saveinfo_filename(args, seed) if args.saveinfo else args.output.format(seed=seed)
+            image.save(path=output_path)
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/utils/dimension_resolver.py
+++ b/src/mflux/utils/dimension_resolver.py
@@ -3,7 +3,13 @@ from pathlib import Path
 import PIL.Image
 
 from mflux.cli.defaults import defaults as ui_defaults
+from mflux.cli.defaults.defaults import DIMENSION_STEP_PIXELS
 from mflux.utils.scale_factor import ScaleFactor
+
+
+def _snap(value: float, step: int = DIMENSION_STEP_PIXELS) -> int:
+    """Round down to the nearest multiple of *step* (default 16)."""
+    return int(value - value % step)
 
 
 class DimensionResolver:
@@ -30,16 +36,30 @@ class DimensionResolver:
         with PIL.Image.open(reference_image_path) as orig_image:
             orig_width, orig_height = orig_image.size
 
-        # Resolve height
-        if height_is_scale:
-            resolved_height = height.get_scaled_value(orig_height)
-        else:
-            resolved_height = int(height)
+        # --- Aspect-ratio-preserving scale propagation ---
+        # When only one dimension carries a non-unity ScaleFactor and the other
+        # is still at the "auto" default (ScaleFactor(1)), propagate the
+        # explicit scale to both dimensions so the reference aspect ratio is
+        # preserved.  E.g. --height 1.2x  →  both dimensions scale by 1.2×.
+        if height_is_scale and width_is_scale:
+            if height.value != 1.0 and width.value == 1.0:
+                width = ScaleFactor(value=height.value)
+            elif width.value != 1.0 and height.value == 1.0:
+                height = ScaleFactor(value=width.value)
 
-        # Resolve width
-        if width_is_scale:
-            resolved_width = width.get_scaled_value(orig_width)
-        else:
-            resolved_width = int(width)
+        # --- Absolute-pixel + auto: infer the other from aspect ratio ---
+        # E.g. --height 800 (int) with width still at auto (ScaleFactor(1)):
+        #   width = 800 × (orig_width / orig_height), snapped to 16 px.
+        if not height_is_scale and width_is_scale and width.value == 1.0:
+            aspect = orig_width / orig_height
+            return _snap(int(height) * aspect), int(height)
+
+        if height_is_scale and height.value == 1.0 and not width_is_scale:
+            aspect = orig_height / orig_width
+            return int(width), _snap(int(width) * aspect)
+
+        # Standard per-dimension resolution
+        resolved_height = height.get_scaled_value(orig_height) if isinstance(height, ScaleFactor) else int(height)
+        resolved_width = width.get_scaled_value(orig_width) if isinstance(width, ScaleFactor) else int(width)
 
         return resolved_width, resolved_height


### PR DESCRIPTION
**Note for Filip**: Feel free to pick what you like from this PR and discard the rest. It's perfectly good to discard this PR and make another with just the things you want to integrate (if any).

**Update**: This PR now also includes aspect-ratio-preserving dimension scaling for img2img workflows.

When a reference image is provided via `--image-path`, you can specify output dimensions (or just one of them) as scale factors:

```
# Scale both dimensions by 1.2× (aspect ratio preserved)
mflux-generate-z-image-turbo \
  --image-path photo.jpg --image-strength 0.3 \
  --height 1.2x --steps 9 --seed 42
 
# Absolute width, height auto-computed from aspect ratio
mflux-generate-z-image-turbo \
  --image-path photo.jpg --image-strength 0.3 \
  --width 800 --steps 9 --seed 42
```

Changes (in `dimension_resolver.py`):

When only one dimension has a non-unity ScaleFactor (e.g. --height 1.2x) and the other is at auto/default, the scale is propagated to both dimensions — preserving the reference image's aspect ratio.
When one dimension is absolute pixels and the other is unspecified, the missing dimension is computed from the reference image's aspect ratio.
Also enabled `supports_dimension_scale_factor=True` for `mflux-generate-z-image` (was already enabled for turbo).
All values snap to multiples of 16. Behavior is unchanged when no reference image is provided.

- --shift: override automatic sigma shift (mu) for both schedulers
- --mcf-max-change: MCF sampler that clamps per-step latent changes
- --cosine / --karras / --exponential: alternative sigma schedules
- --aspect: aspect ratio presets with auto-dimension computation
- --saveinfo: descriptive filenames encoding generation parameters

- All features apply to mflux-generate-z-image-turbo and mflux-generate-z-image
- **NOTE: when no fork-specific flags are used, behavior is identical to upstream**

## Summary (about the rest)

This PR adds several quality-of-life enhancements to the Z-Image and Z-Image Turbo
pipelines, ported from our zima.py CUDA/PyTorch scripts. All features are
**opt-in** — when none of the new flags are used, behavior is **identical to upstream**.

## New CLI Flags

### Noise Schedule Control
- `--shift <float>` — Override the automatic sigma shift (mu) value.
  By default mu is computed from image dimensions. Higher values push the
  noise schedule towards higher noise levels.
- `--cosine` — Smooth S-curve sigma schedule (more steps at high/low noise)
- `--karras` — Karras schedule with rho=7 (concentrates steps on fine details)
- `--exponential` — Log-spaced sigmas between sigma_max and sigma_min
  (_Only one of the three can be used at a time; mutually exclusive group_)

### Sampling
- `--mcf-max-change <float>` — MCF (Mean Change Factor) sampler that clamps
  per-step latent changes to prevent sudden jumps. Typical: 0.05–0.50, min/max 0.01/1.00.

### Convenience
- `--aspect <preset>` — Aspect ratio presets (1:1, 4:3, 3:4, 3:2, 2:3, 16:9,
  9:16, 18:9, 9:18, 21:9, 9:21). **If combined with only `--width` or `--height`,
  the missing dimension is auto-computed and rounded to multiples of 16.**
- `--saveinfo` — Save images with descriptive filenames encoding
  timestamp, seed, steps, LoRA, scheduler, and sigma schedule info
  (convenient, you won't have to look at the EXIF or json for quick reproducibility).

## Modified Files
- `src/mflux/cli/parser/parsers.py` — New args, aspect ratio dict, sigma_schedule resolution; removed `--metadata`
- `src/mflux/models/common/config/config.py` — `sigma_schedule` property
- `src/mflux/models/common/schedulers/linear_scheduler.py` — `_generate_base_sigmas()`
- `src/mflux/models/common/schedulers/flow_match_euler_discrete_scheduler.py` — same
- `src/mflux/models/z_image/variants/z_image.py` — New params in `generate_image()`
- `src/mflux/models/z_image/cli/z_image_turbo_generate.py` — Passthrough + saveinfo
- `src/mflux/models/z_image/cli/z_image_generate.py` — Same
- All CLI entry points (flux, flux2, qwen, z_image, fibo) — Removed `export_json_metadata=args.metadata`

## Testing
All features tested on Apple Silicon (M-series) with both `mflux-generate-z-image-turbo`
and `mflux-generate-z-image`. Baseline output is pixel-identical to upstream when
no new flags are used. See TESTING-SCRIPT.txt for the full test matrix (18 tests).

## Checklist
- [x] No new dependencies added
- [x] All sigma schedule math uses pure MLX (`mx.array`, `mx.cos`, `mx.linspace`)
- [x] Backward-compatible — default behavior unchanged
- [x] Passes existing tests
- [x] Both Z-Image and Z-Image Turbo entry points updated