### PR TITLE
Add: mixed quant inference for flux.2

### DIFF
--- a/src/mflux/models/common/weights/loading/loaded_weights.py
+++ b/src/mflux/models/common/weights/loading/loaded_weights.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass
 class MetaData:
     quantization_level: int | None = None
     mflux_version: str | None = None
+    component_quantization_levels: dict[str, int | None] = None
+
+    def __post_init__(self):
+        if self.component_quantization_levels is None:
+            self.component_quantization_levels = {}
 
 
 @dataclass

--- a/src/mflux/models/common/weights/loading/weight_applier.py
+++ b/src/mflux/models/common/weights/loading/weight_applier.py
@@ -56,7 +56,19 @@ class WeightApplier:
         weight_definition: "WeightDefinitionType",
     ) -> int | None:
         stored_q = weights.meta_data.quantization_level
+        component_quant_levels = weights.meta_data.component_quantization_levels
         components = {c.name: c for c in weight_definition.get_components()}
+
+        if component_quant_levels:
+            return WeightApplier._apply_per_component(
+                weights=weights,
+                models=models,
+                components=components,
+                quantize_arg=quantize_arg,
+                stored_q=stored_q,
+                component_quant_levels=component_quant_levels,
+                weight_definition=weight_definition,
+            )
 
         bits, warning = QuantizationResolution.resolve(stored=stored_q, requested=quantize_arg)
 
@@ -73,6 +85,50 @@ class WeightApplier:
             WeightApplier._set_weights(weights, models, components)
 
         return bits
+
+    @staticmethod
+    def _apply_per_component(
+        weights: LoadedWeights,
+        models: dict[str, nn.Module],
+        components: dict,
+        quantize_arg: int | None,
+        stored_q: int | None,
+        component_quant_levels: dict[str, int | None],
+        weight_definition: "WeightDefinitionType",
+    ) -> int | None:
+        bits_seen = set()
+        for name, model in models.items():
+            component = components.get(name)
+            if component and component.skip_quantization:
+                component_weights = weights.components.get(name)
+                if component_weights is not None:
+                    model.update(component_weights, strict=False)
+                continue
+
+            # Override components use their own stored quant; others fall back to global stored_q
+            comp_stored = component_quant_levels.get(name, stored_q)
+            comp_bits, warning = QuantizationResolution.resolve(stored=comp_stored, requested=quantize_arg)
+            if warning:
+                print(f"⚠️  [{name}] {warning}")
+
+            component_weights = weights.components.get(name)
+            if component_weights is None:
+                continue
+            if component and component.weight_subkey is not None:
+                component_weights = component_weights.get(component.weight_subkey, component_weights)
+
+            if comp_bits is None:
+                model.update(component_weights, strict=False)
+            elif comp_stored is None:
+                model.update(component_weights, strict=False)
+                nn.quantize(model, class_predicate=weight_definition.quantization_predicate, bits=comp_bits)
+            else:
+                nn.quantize(model, class_predicate=weight_definition.quantization_predicate, bits=comp_bits)
+                model.update(component_weights, strict=False)
+
+            bits_seen.add(comp_bits)
+
+        return next(iter(bits_seen)) if len(bits_seen) == 1 else None
 
     @staticmethod
     def _set_weights(

--- a/src/mflux/models/common/weights/loading/weight_loader.py
+++ b/src/mflux/models/common/weights/loading/weight_loader.py
@@ -42,23 +42,39 @@ class WeightLoader:
     def load(
         weight_definition: "WeightDefinitionType",
         model_path: str | None = None,
+        path_overrides: dict[str, str] | None = None,
     ) -> LoadedWeights:
         root_path = PathResolution.resolve(
             path=model_path,
             patterns=weight_definition.get_download_patterns(),
         )
 
-        # 2. Load each component (with caching for shared sources)
         components = {}
         quantization_level = None
         mflux_version = None
+        component_quantization_levels: dict[str, int | None] = {}
         raw_weights_cache: dict[tuple, dict] = {}  # Cache by (path, loading_mode, weight_files)
 
         for component in weight_definition.get_components():
-            weights, q_level, version = WeightLoader._load_component(root_path, component, raw_weights_cache)
+            if path_overrides and component.name in path_overrides:
+                override_root = Path(path_overrides[component.name])
+                if not override_root.exists():
+                    raise FileNotFoundError(
+                        f"--model-{component.name.replace('_', '-')}: path does not exist: {override_root}"
+                    )
+                component_path = override_root / component.hf_subdir
+                if not component_path.exists():
+                    raise FileNotFoundError(
+                        f"--model-{component.name.replace('_', '-')}: expected '{component.hf_subdir}/' subdirectory "
+                        f"not found in {override_root}"
+                    )
+                weights, q_level, version = WeightLoader._load_component(override_root, component)
+                component_quantization_levels[component.name] = q_level
+            else:
+                weights, q_level, version = WeightLoader._load_component(root_path, component, raw_weights_cache)
+
             components[component.name] = weights
 
-            # Track metadata from first component that has it
             if quantization_level is None and q_level is not None:
                 quantization_level = q_level
                 mflux_version = version
@@ -68,6 +84,7 @@ class WeightLoader:
             meta_data=MetaData(
                 quantization_level=quantization_level,
                 mflux_version=mflux_version,
+                component_quantization_levels=component_quantization_levels,
             ),
         )
 

--- a/src/mflux/models/flux2/cli/flux2_edit_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_edit_generate.py
@@ -16,6 +16,8 @@ def main():
     parser = CommandLineParser(description="Generate an image using Flux2 Klein Edit with image conditioning.")
     parser.add_general_arguments()
     parser.add_model_arguments(require_model_arg=False)
+    parser.add_argument("--model-transformer", type=str, default=None, help="Path to a model directory to load the transformer from (overrides --model-path for this component).")  # fmt: off
+    parser.add_argument("--model-text-encoder", type=str, default=None, help="Path to a model directory to load the text encoder from (overrides --model-path for this component).")  # fmt: off
     parser.add_lora_arguments()
     parser.add_argument("--image-paths", type=Path, nargs="+", required=True, help="Local paths to one or more init images. For single image editing, provide one path. For multiple image editing, provide multiple paths.")  # fmt: off
     parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
@@ -44,6 +46,8 @@ def main():
         model_path=args.model_path,
         lora_paths=args.lora_paths,
         lora_scales=args.lora_scales,
+        transformer_path=args.model_transformer,
+        text_encoder_path=args.model_text_encoder,
     )
 
     memory_saver = CallbackManager.register_callbacks(

--- a/src/mflux/models/flux2/cli/flux2_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_generate.py
@@ -14,6 +14,8 @@ def main():
     parser = CommandLineParser(description="Generate an image using Flux2 Klein.")
     parser.add_general_arguments()
     parser.add_model_arguments(require_model_arg=False)
+    parser.add_argument("--model-transformer", type=str, default=None, help="Path to a model directory to load the transformer from (overrides --model-path for this component).")  # fmt: off
+    parser.add_argument("--model-text-encoder", type=str, default=None, help="Path to a model directory to load the text encoder from (overrides --model-path for this component).")  # fmt: off
     parser.add_lora_arguments()
     parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
     parser.add_image_to_image_arguments(required=False)
@@ -38,6 +40,8 @@ def main():
         model_path=args.model_path,
         lora_paths=args.lora_paths,
         lora_scales=args.lora_scales,
+        transformer_path=args.model_transformer,
+        text_encoder_path=args.model_text_encoder,
     )
 
     memory_saver = CallbackManager.register_callbacks(

--- a/src/mflux/models/flux2/flux2_initializer.py
+++ b/src/mflux/models/flux2/flux2_initializer.py
@@ -21,10 +21,17 @@ class Flux2Initializer:
         model_path: str | None = None,
         lora_paths: list[str] | None = None,
         lora_scales: list[float] | None = None,
+        transformer_path: str | None = None,
+        text_encoder_path: str | None = None,
     ) -> None:
         path = model_path if model_path else model_config.model_name
+        path_overrides = {}
+        if transformer_path:
+            path_overrides["transformer"] = transformer_path
+        if text_encoder_path:
+            path_overrides["text_encoder"] = text_encoder_path
         Flux2Initializer._init_config(model, model_config)
-        weights = Flux2Initializer._load_weights(path)
+        weights = Flux2Initializer._load_weights(path, path_overrides or None)
         Flux2Initializer._init_tokenizers(model, path)
         Flux2Initializer._init_models(model)
         Flux2Initializer._apply_weights(model, weights, quantize)
@@ -38,10 +45,11 @@ class Flux2Initializer:
         model.tiling_config = None
 
     @staticmethod
-    def _load_weights(model_path: str) -> LoadedWeights:
+    def _load_weights(model_path: str, path_overrides: dict[str, str] | None = None) -> LoadedWeights:
         return WeightLoader.load(
             weight_definition=Flux2KleinWeightDefinition,
             model_path=model_path,
+            path_overrides=path_overrides,
         )
 
     @staticmethod

--- a/src/mflux/models/flux2/variants/edit/flux2_klein_edit.py
+++ b/src/mflux/models/flux2/variants/edit/flux2_klein_edit.py
@@ -29,6 +29,8 @@ class Flux2KleinEdit(nn.Module):
         lora_paths: list[str] | None = None,
         lora_scales: list[float] | None = None,
         model_config: ModelConfig | None = None,
+        transformer_path: str | None = None,
+        text_encoder_path: str | None = None,
     ):
         super().__init__()
         Flux2Initializer.init(
@@ -38,6 +40,8 @@ class Flux2KleinEdit(nn.Module):
             lora_paths=lora_paths,
             lora_scales=lora_scales,
             model_config=model_config or ModelConfig.flux2_klein_4b(),
+            transformer_path=transformer_path,
+            text_encoder_path=text_encoder_path,
         )
 
     def generate_image(

--- a/src/mflux/models/flux2/variants/txt2img/flux2_klein.py
+++ b/src/mflux/models/flux2/variants/txt2img/flux2_klein.py
@@ -33,6 +33,8 @@ class Flux2Klein(nn.Module):
         lora_paths: list[str] | None = None,
         lora_scales: list[float] | None = None,
         model_config: ModelConfig | None = None,
+        transformer_path: str | None = None,
+        text_encoder_path: str | None = None,
     ):
         super().__init__()
         Flux2Initializer.init(
@@ -42,6 +44,8 @@ class Flux2Klein(nn.Module):
             lora_paths=lora_paths,
             lora_scales=lora_scales,
             model_config=model_config or ModelConfig.flux2_klein_4b(),
+            transformer_path=transformer_path,
+            text_encoder_path=text_encoder_path,
         )
 
     def generate_image(

--- a/xx.md
+++ b/xx.md
@@ -1,0 +1,6 @@
+
+
+
+8-8 MLX memory: 19.84 GB
+8-6 MLX memory: 19.84 GB 
+8-4 MLX memory:  GB 


### PR DESCRIPTION
Currently mflux supports a range of model quantizations (3,4,5,6,8) - though the quantization of the transformer models and the text-encoders always matched. Quantization does not touch the VAE - it remains bf16.

We know that quantization of the VAE would quickly and severely degrades image quality. That quantization of the transformer model visibly degrades the image quality somewhat. Though text-encode quantization is genrally handled well.

This PR uncoupled the quantization of the transformer and text encoder so you can mix and match according to your requirements.

This PR simply adds an optional extra command line argument `model-text-encoder`

**Flux.2 Klein**
```
mflux-generate-flux2-edit \
    --model FLUX.2-klein-9b-kv-mflux-8bit \
    --model-text-encoder FLUX.2-klein-9b-kv-mflux-3bit \
    --prompt "A puffin standing on a cliff" \
    --steps 4 \
    --seed 42 \
    --output puffin.png
 ```    

**Flux.2 Klein Edit**
```
mflux-generate-flux2-edit \
    --model FLUX.2-klein-9b-kv-mflux-8bit \
    --model-text-encoder FLUX.2-klein-9b-kv-mflux-3bit \
    --image-paths puffin.png \
    --prompt "Change the color of the bird's chest and front from white to hot pink, keep the head white and black" \
    --steps 4 \
    --seed 42 \
    --output puffin-edit.png
 ```    

**T2I: transformer q8 / text-encoder q8**
<img width="1024" height="1024" alt="puffin-8-8" src="https://github.com/user-attachments/assets/c9baa40e-7a7d-4cce-bf77-0d3bcd6658f1" />

**T2I: transformer q8 / text-encoder q6**
<img width="1024" height="1024" alt="puffin-8-6" src="https://github.com/user-attachments/assets/c1552b61-15da-4db1-923f-60f217d292a9" />

**T2I: transformer q8 / text-encoder q3**
<img width="1024" height="1024" alt="puffin-8-3" src="https://github.com/user-attachments/assets/a9fccbe8-839b-4d20-8565-91d2a7ee020a" />

**I2I: transformer q5 / text-encoder q3**
<img width="512" height="512" alt="puffin-edit-5-3" src="https://github.com/user-attachments/assets/25571c33-afcb-4e82-8221-11137f6ba01f" />

**I2I: transformer q3 / text-encoder q3**
<img width="512" height="512" alt="puffin-edit-3-3" src="https://github.com/user-attachments/assets/641a1f16-7dc8-42ab-8cbb-4623b48c0025" />

### Flux.21 Models Sizes by quant (Gb)
|Quant | Transformers | Text Encoder |
|-- | -- | -- |
|q8 | 9.65 | 8.04 |
|q6 | 7.38 | 6.15 |
|q5 | 6.24 | 5.2 |
|q4 | 5.11 | 4.26 |
|q3 | 3.97 | 3.31 |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR allows Flux2 transformer and text-encoder weights to be loaded from separate model roots and applies their stored quantization levels independently.
- Adds component-specific model options to both Flux2 generation CLIs and Python constructors.
- Extends loaded-weight metadata and application logic for per-component quantization.
- The new override resolution rejects non-local model identifiers, and mixed levels are not preserved across model saves.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until component identifiers resolve consistently and mixed quantization metadata survives model save and reload.

Remote component identifiers currently fail before download resolution, while mixed quantization is represented as an unquantized model when persisted, breaking supported invocation and checkpoint round trips.

**Files Needing Attention:** src/mflux/models/common/weights/loading/weight_loader.py, src/mflux/models/common/weights/loading/weight_applier.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/common/weights/loading/weight_loader.py | Adds component-root loading and quantization metadata, but bypasses standard resolution for remote model identifiers. |
| src/mflux/models/common/weights/loading/weight_applier.py | Applies quantization independently per component but collapses mixed levels to None, losing persistence metadata. |
| src/mflux/models/flux2/flux2_initializer.py | Wires optional component overrides into loading while retaining the base model for configuration and tokenizers. |
| src/mflux/models/flux2/cli/flux2_generate.py | Exposes transformer and text-encoder component model options for text-to-image generation. |
| src/mflux/models/flux2/cli/flux2_edit_generate.py | Exposes the same component model options for edit generation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  CLI[Flux2 CLI component options] --> Init[Flux2Initializer path overrides]
  Init --> Loader[WeightLoader loads component roots]
  Loader --> Meta[Per-component quantization metadata]
  Meta --> Apply[WeightApplier quantizes and updates components]
  Apply --> Bits[model.bits]
  Bits --> Save[Model and image metadata]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/mflux/models/common/weights/loading/weight_loader.py:59-64
**Component identifiers bypass resolution**

When `--model-text-encoder` or `--model-transformer` receives a Hugging Face repository identifier, this branch treats it only as a local path and raises `FileNotFoundError` instead of resolving or downloading the component model.

### Issue 2
src/mflux/models/common/weights/loading/weight_applier.py:129
**Mixed quantization metadata is discarded**

When the transformer and text encoder use different bit levels, this returns `None`, which is stored as `model.bits`; saving then records the checkpoint as unquantized, so reload does not recreate the component-specific quantized layouts and breaks the save/reload round trip.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["mixed quant inference for mflux-generate..."](https://github.com/mflux-community/mflux/commit/638a58ea03070164768aa3c9f645cd7dad60f7a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51896723)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->