### PR TITLE
Boogu: --metadata writes a null sidecar

### DIFF
--- a/src/mflux/models/boogu/cli/boogu_image_generate.py
+++ b/src/mflux/models/boogu/cli/boogu_image_generate.py
@@ -3,7 +3,6 @@ from mflux.cli.parser.parsers import CommandLineParser
 from mflux.models.boogu.variants import BooguImage
 from mflux.models.common.config import ModelConfig
 from mflux.utils.exceptions import PromptFileReadError, StopImageGenerationException
-from mflux.utils.image_util import ImageUtil
 from mflux.utils.prompt_util import PromptUtil
 
 
@@ -42,11 +41,7 @@ def main():
                 height=args.height,
                 num_inference_steps=args.steps,
             )
-            ImageUtil.save_image(
-                image=image,
-                path=args.output.format(seed=seed),
-                export_json_metadata=args.metadata,
-            )
+            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/tests/cli/test_boogu_metadata_sidecar.py
+++ b/tests/cli/test_boogu_metadata_sidecar.py
@@ -1,0 +1,64 @@
+import json
+import sys
+
+import mlx.core as mx
+import pytest
+
+from mflux.models.boogu.cli import boogu_image_generate
+from mflux.models.common.config import ModelConfig
+from mflux.models.common.config.config import Config
+from mflux.utils.image_util import ImageUtil
+
+
+def _generated_image():
+    config = Config(model_config=ModelConfig.boogu_image_turbo(), num_inference_steps=4, height=64, width=64)
+    return ImageUtil.to_image(
+        decoded_latents=mx.zeros((1, 3, 64, 64)),
+        config=config,
+        seed=7,
+        prompt="a red cube",
+        quantization=8,
+        generation_time=1.0,
+    )
+
+
+@pytest.mark.fast
+def test_the_cli_writes_generation_parameters_to_the_sidecar(tmp_path, monkeypatch):
+    # The CLI used to hand its GeneratedImage to ImageUtil.save_image as if it were a PIL
+    # image. That call re-entered GeneratedImage.save through image.save(path), so the
+    # embedded metadata survived while the outer call wrote the sidecar with metadata=None,
+    # and json.dump turned it into the four bytes "null".
+    generated = _generated_image()
+
+    class _StubModel:
+        def __init__(self, **kwargs):
+            pass
+
+        def generate_image(self, **kwargs):
+            return generated
+
+    monkeypatch.setattr(boogu_image_generate, "BooguImage", _StubModel)
+    monkeypatch.setattr(boogu_image_generate.CallbackManager, "register_callbacks", lambda **kwargs: None)
+    output = tmp_path / "out.png"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "mflux-generate-boogu",
+            "--prompt",
+            "a red cube",
+            "--seed",
+            "7",
+            "--steps",
+            "4",
+            "--metadata",
+            "--output",
+            str(output),
+        ],
+    )
+
+    boogu_image_generate.main()
+
+    sidecar = json.loads(output.with_suffix(".metadata.json").read_text())
+    assert sidecar["seed"] == 7
+    assert sidecar["prompt"] == "a red cube"


### PR DESCRIPTION
Closes #570.

`mflux-generate-boogu --metadata` writes a sidecar holding the literal `null` rather than the generation parameters.

The CLI hands its `GeneratedImage` to `ImageUtil.save_image()` as if it were a PIL image. `save_image` calls `image.save(file_path)`, which lands back in `GeneratedImage.save()` and re-enters with its own metadata, so the PNG does keep its embedded xmp/IPTC/exif. The sidecar comes from the outer call, whose `metadata` argument is None, and `json.dump(None)` is four bytes.

The fix is the call every other generate CLI already makes. Same shape as #493, which #492 fixed for the FLUX.2 CLIs.

The test drives `main()` with a stub model, so it needs no weights, and it fails on the old call with `TypeError: 'NoneType' object is not subscriptable` when it reads the sidecar back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image generation output handling while preserving configured paths and metadata.
  * Ensured metadata sidecar files correctly include the generation seed and prompt.

* **Tests**
  * Added regression coverage for metadata generation through the command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Boogu metadata sidecar generation by saving through `GeneratedImage.save()`, which supplies the generation metadata instead of serializing `None`.
- Removes the incorrect direct `ImageUtil.save_image()` call from the Boogu CLI.
- Adds a CLI regression test asserting that exported sidecars contain the generation seed and prompt.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the corrected save path preserving image output while supplying metadata to the optional sidecar.

Boogu generation always returns a `GeneratedImage`, whose save method accepts the supplied path and metadata-export flag and forwards its generation metadata to the sidecar writer; the regression test exercises that CLI path.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/boogu/cli/boogu_image_generate.py | Correctly delegates saving to `GeneratedImage.save()`, matching its contract and the established sibling-CLI pattern. |
| tests/cli/test_boogu_metadata_sidecar.py | Adds focused regression coverage that invokes the CLI with a stub model and verifies generation parameters in the JSON sidecar. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Boogu: save through GeneratedImage so --..."](https://github.com/mflux-community/mflux/commit/94327f1867e771294310096fff750eb80d38d1f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52676794)</sub>

<!-- /greptile_comment -->