### PR TITLE
Lens: wire callbacks and the ignored-option warning

### DIFF
--- a/src/mflux/models/lens/cli/lens_generate.py
+++ b/src/mflux/models/lens/cli/lens_generate.py
@@ -1,5 +1,7 @@
+from mflux.callbacks.callback_manager import CallbackManager
 from mflux.cli.parser.parsers import CommandLineParser
 from mflux.models.common.config import ModelConfig
+from mflux.models.flux2.latent_creator.flux2_latent_creator import Flux2LatentCreator
 from mflux.models.lens.variants.txt2img.lens_image import LensImage
 from mflux.utils.dimension_resolver import DimensionResolver
 from mflux.utils.exceptions import ModelConfigError, PromptFileReadError, StopImageGenerationException
@@ -10,6 +12,7 @@ from mflux.utils.prompt_util import PromptUtil
 IGNORED_OPTIONS = {
     "--guidance": "Lens Turbo is a 4-step distillation with CFG internalized; guidance is never applied.",
     "--negative-prompt": "CFG is disabled on Lens Turbo, so the negative prompt is never encoded.",
+    "--scheduler": "Lens Turbo runs the shifted sigma schedule its distillation was trained on.",
 }
 
 
@@ -25,6 +28,7 @@ def build_parser() -> CommandLineParser:
 def main():
     parser = build_parser()
     args = parser.parse_args()
+    CommandLineParser.warn_ignored_options(IGNORED_OPTIONS)
 
     model_config = ModelConfig.lens_turbo()
     if args.model is not None:
@@ -45,6 +49,14 @@ def main():
         model_path=args.model_path,
     )
 
+    # Lens rides FLUX.2 latents, so the flux2 unpacker is the one that turns its packed
+    # (1, seq, 128) tensor back into something the VAE can decode for stepwise output.
+    memory_saver = CallbackManager.register_callbacks(
+        args=args,
+        model=model,
+        latent_creator=Flux2LatentCreator,
+    )
+
     try:
         width, height = DimensionResolver.resolve(width=args.width, height=args.height)
         for seed in args.seed:
@@ -58,6 +70,9 @@ def main():
             image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
+    finally:
+        if memory_saver:
+            print(memory_saver.memory_stats())
 
 
 if __name__ == "__main__":

--- a/src/mflux/models/lens/variants/txt2img/lens_image.py
+++ b/src/mflux/models/lens/variants/txt2img/lens_image.py
@@ -14,6 +14,7 @@ import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_unflatten
 
+from mflux.callbacks.callback_registry import CallbackRegistry
 from mflux.models.common.config import ModelConfig
 from mflux.models.common.config.config import Config
 from mflux.models.common.resolution.path_resolution import PathResolution
@@ -26,6 +27,7 @@ from mflux.models.lens.model.text_encoder.lens_gpt_oss_encoder import (
     LensGptOssEncoder,
 )
 from mflux.models.lens.model.transformer.lens_transformer import LensTransformer
+from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.image_util import ImageUtil
 
 TURBO_WEIGHTS_PATTERN = "diffusion_models/lens_turbo_bf16.safetensors"
@@ -42,6 +44,7 @@ class LensImage:
     ):
         self.model_config = model_config or ModelConfig.lens_turbo()
         self.bits = quantize
+        self.callbacks = CallbackRegistry()
 
         encoder_root = PathResolution.resolve(
             path=encoder_path or DEFAULT_ENCODER_REPO,
@@ -73,7 +76,6 @@ class LensImage:
         width: int = 1024,
         height: int = 1024,
         num_inference_steps: int = 4,
-        **_ignored,
     ):
         start = time.time()
         config = Config(
@@ -93,16 +95,24 @@ class LensImage:
         mx.random.seed(seed)
         latents = mx.random.normal((1, seq, 128), dtype=mx.float32).astype(mx.bfloat16)
 
-        for i in range(num_inference_steps):
-            velocity = self.transformer(
-                hidden_states=latents,
-                encoder_layers=features,
-                timestep=mx.array([sigmas[i]]),
-                latent_height=latent_height,
-                latent_width=latent_width,
-            )
-            latents = latents + (sigmas[i + 1] - sigmas[i]) * velocity
-            mx.eval(latents)
+        ctx = self.callbacks.start(seed=seed, prompt=prompt, config=config)
+        ctx.before_loop(latents)
+        for i in config.time_steps:
+            try:
+                velocity = self.transformer(
+                    hidden_states=latents,
+                    encoder_layers=features,
+                    timestep=mx.array([sigmas[i]]),
+                    latent_height=latent_height,
+                    latent_width=latent_width,
+                )
+                latents = latents + (sigmas[i + 1] - sigmas[i]) * velocity
+                ctx.in_loop(i, latents)
+                mx.eval(latents)
+            except KeyboardInterrupt:  # noqa: PERF203
+                ctx.interruption(i, latents)
+                raise StopImageGenerationException(f"Stopping image generation at step {i + 1}/{num_inference_steps}")
+        ctx.after_loop(latents)
 
         packed = latents.reshape(1, latent_height, latent_width, 128).transpose(0, 3, 1, 2)
         decoded = self.vae.decode_packed_latents(packed.astype(mx.float32))


### PR DESCRIPTION
Part of the Lens item in #578, from my own #510.

Four options were accepted and inert: `--low-ram`, `--battery-percentage-stop-limit`, `--stepwise-image-output-dir` and, through `**_ignored`, anything misspelled. The CLI now registers callbacks. The latent creator is the flux2 one, since Lens runs on FLUX.2 latents and that is the unpacker that turns its packed `(1, seq, 128)` tensor into something `decode_packed_latents` accepts. The loop iterates `config.time_steps`, which also gives Lens the progress bar the other models have.

`IGNORED_OPTIONS` was declared and `warn_ignored_options` was never called, which is the split #499 exists to prevent, in the module I wrote. `--scheduler` joins the list rather than staying silent: the parser accepts it and the code always runs the shifted schedule the distillation was trained on.

`generate_image` no longer takes `**_ignored`.

Verified on an M5 Max, same prompt and seed before and after: byte-identical output at 512x512 in 4 steps, `--guidance` now warns, and `--stepwise-image-output-dir` writes its five frames plus the composite where it used to write nothing.

Not in here: the loader. The encoder is a pre-quantized MXFP4 mlx-community checkpoint that carries its own quantization, so it does not go through `WeightApplier`, and moving it onto `WeightDefinition` is a rewrite whose only real verification is loading a 20B encoder. That belongs in its own PR rather than riding along with flag wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added callback-based generation lifecycle support for improved progress and memory reporting.
  * Added latent evaluation during image generation steps.
  * Added clearer handling for keyboard interruptions, stopping generation gracefully.

* **Bug Fixes**
  * Improved warnings for unsupported command-line options, including scheduler settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR activates the existing Lens CLI callback and ignored-option infrastructure without changing its generation result.
- Registers low-memory, battery-limit, and stepwise-image callbacks using the FLUX.2 latent unpacker.
- Runs the Lens denoising loop through the shared callback lifecycle and progress iterator.
- Warns when accepted Lens options have no runtime effect and reports memory statistics when requested.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defect identified in the changed paths.

The callback lifecycle matches existing FLUX.2 implementations, the selected latent creator is shape-compatible with Lens tensors and its VAE, callback image conversion synchronizes lazy MLX results before host use, and the timestep iterator preserves the existing Lens schedule.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/lens/cli/lens_generate.py | Registers the shared callbacks, emits warnings for accepted-but-inert options, and prints optional memory statistics using established sibling-CLI patterns. |
| src/mflux/models/lens/variants/txt2img/lens_image.py | Adds the shared callback lifecycle and progress iterator around denoising while retaining compatible FLUX.2 packed latent shapes and sigma indexing. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as Lens CLI
    participant CM as CallbackManager
    participant Lens as LensImage
    participant CB as CallbackRegistry
    participant VAE as FLUX.2 VAE
    CLI->>CM: register_callbacks(args, model, Flux2LatentCreator)
    CLI->>Lens: generate_image(...)
    Lens->>CB: before_loop(latents)
    loop config.time_steps
        Lens->>Lens: transformer denoise step
        Lens->>CB: in_loop(step, latents)
        Lens->>Lens: mx.eval(latents)
    end
    Lens->>CB: after_loop(latents)
    Lens->>VAE: decode_packed_latents(latents)
    VAE-->>CLI: generated image
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Lens: wire the callbacks and the warning..."](https://github.com/mflux-community/mflux/commit/299280f0fd4c3d14eed6fbed4669923e4280014d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53085513)</sub>

<!-- /greptile_comment -->