### PR TITLE
[RFC] test: hermetic tiny-checkpoint fixtures for the save/load seam (proposal + demo on 2 models)

### DIFF
--- a/tests/model_saving/test_tiny_model_saving_ernie_image.py
+++ b/tests/model_saving/test_tiny_model_saving_ernie_image.py
@@ -6,42 +6,43 @@ from mflux.models.ernie_image.weights.ernie_weight_definition import ErnieWeight
 from tests.model_saving.tiny_checkpoint_helper import TinyCheckpointRoundtrip, TinyVAEStandIn
 
 
-def _tiny_components():
-    # Every dimension is a multiple of 64 (MLX's quantization group size) so the
-    # tiny components quantize exactly like the full-size checkpoint does.
-    # rope_axes_dim must sum to head_dim (128 / 2 heads = 64).
-    return {
-        "vae": TinyVAEStandIn(),
-        "transformer": ErnieTransformer(
-            hidden_size=128,
-            num_attention_heads=2,
-            num_layers=2,
-            ffn_hidden_size=128,
-            in_channels=64,
-            out_channels=64,
-            text_in_dim=64,
-            rope_axes_dim=[16, 24, 24],
-        ),
-        "text_encoder": ErnieMistralTextEncoder(
-            vocab_size=128,
-            hidden_size=128,
-            num_hidden_layers=2,
-            num_attention_heads=2,
-            num_key_value_heads=1,
-            head_dim=64,
-            intermediate_size=128,
-        ),
-    }
+class TestTinyErnieModelSaving:
+    @pytest.mark.fast
+    def test_tiny_quantized_checkpoint_roundtrips_exactly(self, tmp_path):
+        # Fast twin of tests/model_saving/test_model_saving_ernie_image.py: the same
+        # ModelSaver -> WeightLoader -> WeightApplier seam, with real ERNIE component
+        # classes at tiny dimensions instead of the downloaded full-size checkpoint.
+        TinyCheckpointRoundtrip.save_and_reload_expecting_identical_weights(
+            weight_definition=ErnieWeightDefinition,
+            make_components=TestTinyErnieModelSaving._tiny_components,
+            base_path=tmp_path / "ernie_tiny_q8",
+            bits=8,
+        )
 
-
-@pytest.mark.fast
-def test_tiny_quantized_ernie_checkpoint_roundtrips_exactly(tmp_path):
-    # Fast twin of tests/model_saving/test_model_saving_ernie_image.py: the same
-    # ModelSaver -> WeightLoader -> WeightApplier seam, with real ERNIE component
-    # classes at tiny dimensions instead of the downloaded full-size checkpoint.
-    TinyCheckpointRoundtrip.save_and_reload_expecting_identical_weights(
-        weight_definition=ErnieWeightDefinition,
-        make_components=_tiny_components,
-        base_path=tmp_path / "ernie_tiny_q8",
-        bits=8,
-    )
+    @staticmethod
+    def _tiny_components():
+        # Every dimension is a multiple of 64 (MLX's quantization group size) so the
+        # tiny components quantize exactly like the full-size checkpoint does.
+        # rope_axes_dim must sum to head_dim (128 / 2 heads = 64).
+        return {
+            "vae": TinyVAEStandIn(),
+            "transformer": ErnieTransformer(
+                hidden_size=128,
+                num_attention_heads=2,
+                num_layers=2,
+                ffn_hidden_size=128,
+                in_channels=64,
+                out_channels=64,
+                text_in_dim=64,
+                rope_axes_dim=[16, 24, 24],
+            ),
+            "text_encoder": ErnieMistralTextEncoder(
+                vocab_size=128,
+                hidden_size=128,
+                num_hidden_layers=2,
+                num_attention_heads=2,
+                num_key_value_heads=1,
+                head_dim=64,
+                intermediate_size=128,
+            ),
+        }

--- a/tests/model_saving/test_tiny_model_saving_ernie_image.py
+++ b/tests/model_saving/test_tiny_model_saving_ernie_image.py
@@ -1,0 +1,47 @@
+import pytest
+
+from mflux.models.ernie_image.model.ernie_text_encoder.text_encoder import ErnieMistralTextEncoder
+from mflux.models.ernie_image.model.ernie_transformer.transformer import ErnieTransformer
+from mflux.models.ernie_image.weights.ernie_weight_definition import ErnieWeightDefinition
+from tests.model_saving.tiny_checkpoint_helper import TinyCheckpointRoundtrip, TinyVAEStandIn
+
+
+def _tiny_components():
+    # Every dimension is a multiple of 64 (MLX's quantization group size) so the
+    # tiny components quantize exactly like the full-size checkpoint does.
+    # rope_axes_dim must sum to head_dim (128 / 2 heads = 64).
+    return {
+        "vae": TinyVAEStandIn(),
+        "transformer": ErnieTransformer(
+            hidden_size=128,
+            num_attention_heads=2,
+            num_layers=2,
+            ffn_hidden_size=128,
+            in_channels=64,
+            out_channels=64,
+            text_in_dim=64,
+            rope_axes_dim=[16, 24, 24],
+        ),
+        "text_encoder": ErnieMistralTextEncoder(
+            vocab_size=128,
+            hidden_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=64,
+            intermediate_size=128,
+        ),
+    }
+
+
+@pytest.mark.fast
+def test_tiny_quantized_ernie_checkpoint_roundtrips_exactly(tmp_path):
+    # Fast twin of tests/model_saving/test_model_saving_ernie_image.py: the same
+    # ModelSaver -> WeightLoader -> WeightApplier seam, with real ERNIE component
+    # classes at tiny dimensions instead of the downloaded full-size checkpoint.
+    TinyCheckpointRoundtrip.save_and_reload_expecting_identical_weights(
+        weight_definition=ErnieWeightDefinition,
+        make_components=_tiny_components,
+        base_path=tmp_path / "ernie_tiny_q8",
+        bits=8,
+    )

--- a/tests/model_saving/test_tiny_model_saving_ernie_image.py
+++ b/tests/model_saving/test_tiny_model_saving_ernie_image.py
@@ -17,6 +17,9 @@ class TestTinyErnieModelSaving:
             make_components=TestTinyErnieModelSaving._tiny_components,
             base_path=tmp_path / "ernie_tiny_q8",
             bits=8,
+            # Force shard boundaries so index.json/weight_map multi-shard paths are
+            # exercised — the size-based split never shards test-sized tensors.
+            tensors_per_shard=8,
         )
 
     @staticmethod

--- a/tests/model_saving/test_tiny_model_saving_ideogram4.py
+++ b/tests/model_saving/test_tiny_model_saving_ideogram4.py
@@ -29,6 +29,9 @@ class TestTinyIdeogram4ModelSaving:
             make_components=TestTinyIdeogram4ModelSaving._tiny_components,
             base_path=tmp_path / "ideogram4_tiny_q8",
             bits=8,
+            # Force shard boundaries so index.json/weight_map multi-shard paths are
+            # exercised — the size-based split never shards test-sized tensors.
+            tensors_per_shard=8,
         )
 
     @staticmethod

--- a/tests/model_saving/test_tiny_model_saving_ideogram4.py
+++ b/tests/model_saving/test_tiny_model_saving_ideogram4.py
@@ -17,32 +17,33 @@ TINY_TRANSFORMER_CONFIG = Ideogram4Config(
 )
 
 
-def _tiny_components():
-    return {
-        "vae": TinyVAEStandIn(),
-        "conditional_transformer": Ideogram4Transformer(TINY_TRANSFORMER_CONFIG),
-        "unconditional_transformer": Ideogram4Transformer(TINY_TRANSFORMER_CONFIG),
-        "text_encoder": Qwen3TextEncoder(
-            vocab_size=128,
-            hidden_size=128,
-            num_hidden_layers=2,
-            num_attention_heads=2,
-            num_key_value_heads=1,
-            intermediate_size=128,
-            head_dim=64,
-        ),
-    }
+class TestTinyIdeogram4ModelSaving:
+    @pytest.mark.fast
+    def test_tiny_quantized_checkpoint_roundtrips_exactly(self, tmp_path):
+        # Fast twin of tests/model_saving/test_model_saving_ideogram4.py: the same
+        # ModelSaver -> WeightLoader -> WeightApplier seam, with real Ideogram 4
+        # component classes (incl. Fp8Linear layers) at tiny dimensions instead of
+        # the downloaded 26 GB checkpoint.
+        TinyCheckpointRoundtrip.save_and_reload_expecting_identical_weights(
+            weight_definition=Ideogram4WeightDefinition,
+            make_components=TestTinyIdeogram4ModelSaving._tiny_components,
+            base_path=tmp_path / "ideogram4_tiny_q8",
+            bits=8,
+        )
 
-
-@pytest.mark.fast
-def test_tiny_quantized_ideogram4_checkpoint_roundtrips_exactly(tmp_path):
-    # Fast twin of tests/model_saving/test_model_saving_ideogram4.py: the same
-    # ModelSaver -> WeightLoader -> WeightApplier seam, with real Ideogram 4
-    # component classes (incl. Fp8Linear layers) at tiny dimensions instead of
-    # the downloaded 26 GB checkpoint.
-    TinyCheckpointRoundtrip.save_and_reload_expecting_identical_weights(
-        weight_definition=Ideogram4WeightDefinition,
-        make_components=_tiny_components,
-        base_path=tmp_path / "ideogram4_tiny_q8",
-        bits=8,
-    )
+    @staticmethod
+    def _tiny_components():
+        return {
+            "vae": TinyVAEStandIn(),
+            "conditional_transformer": Ideogram4Transformer(TINY_TRANSFORMER_CONFIG),
+            "unconditional_transformer": Ideogram4Transformer(TINY_TRANSFORMER_CONFIG),
+            "text_encoder": Qwen3TextEncoder(
+                vocab_size=128,
+                hidden_size=128,
+                num_hidden_layers=2,
+                num_attention_heads=2,
+                num_key_value_heads=1,
+                intermediate_size=128,
+                head_dim=64,
+            ),
+        }

--- a/tests/model_saving/test_tiny_model_saving_ideogram4.py
+++ b/tests/model_saving/test_tiny_model_saving_ideogram4.py
@@ -1,0 +1,48 @@
+import pytest
+
+from mflux.models.ideogram4.model import Ideogram4Config, Ideogram4Transformer, Qwen3TextEncoder
+from mflux.models.ideogram4.weights.ideogram4_weight_definition import Ideogram4WeightDefinition
+from tests.model_saving.tiny_checkpoint_helper import TinyCheckpointRoundtrip, TinyVAEStandIn
+
+# Every dimension is a multiple of 64 (MLX's quantization group size) so the
+# tiny components quantize exactly like the full-size checkpoint does.
+TINY_TRANSFORMER_CONFIG = Ideogram4Config(
+    emb_dim=128,
+    num_layers=2,
+    num_heads=2,
+    intermediate_size=128,
+    adanln_dim=64,
+    in_channels=64,
+    llm_features_dim=128,
+)
+
+
+def _tiny_components():
+    return {
+        "vae": TinyVAEStandIn(),
+        "conditional_transformer": Ideogram4Transformer(TINY_TRANSFORMER_CONFIG),
+        "unconditional_transformer": Ideogram4Transformer(TINY_TRANSFORMER_CONFIG),
+        "text_encoder": Qwen3TextEncoder(
+            vocab_size=128,
+            hidden_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            intermediate_size=128,
+            head_dim=64,
+        ),
+    }
+
+
+@pytest.mark.fast
+def test_tiny_quantized_ideogram4_checkpoint_roundtrips_exactly(tmp_path):
+    # Fast twin of tests/model_saving/test_model_saving_ideogram4.py: the same
+    # ModelSaver -> WeightLoader -> WeightApplier seam, with real Ideogram 4
+    # component classes (incl. Fp8Linear layers) at tiny dimensions instead of
+    # the downloaded 26 GB checkpoint.
+    TinyCheckpointRoundtrip.save_and_reload_expecting_identical_weights(
+        weight_definition=Ideogram4WeightDefinition,
+        make_components=_tiny_components,
+        base_path=tmp_path / "ideogram4_tiny_q8",
+        bits=8,
+    )

--- a/tests/model_saving/tiny_checkpoint_helper.py
+++ b/tests/model_saving/tiny_checkpoint_helper.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+import mlx.core as mx
+from mlx import nn
+from mlx.utils import tree_flatten, tree_unflatten
+
+from mflux.models.common.weights.loading.weight_applier import WeightApplier
+from mflux.models.common.weights.loading.weight_loader import WeightLoader
+from mflux.models.common.weights.saving.model_saver import ModelSaver
+from mflux.utils.version_util import VersionUtil
+
+
+class TinyVAEStandIn(nn.Module):
+    # The real VAEs are fixed-size (~170M param) architectures with no dimension
+    # knobs. ModelSaver/WeightLoader treat every component as an opaque parameter
+    # tree, so a small module walks the identical save/load code path.
+    def __init__(self):
+        super().__init__()
+        self.conv_in = nn.Conv2d(3, 64, kernel_size=3)
+        self.proj = nn.Linear(64, 64)
+
+
+class TinyCheckpointRoundtrip:
+    # Hermetic twin of the slow save/load tests: quantize tiny real components,
+    # save them through ModelSaver (real shard/index/metadata writing), reload
+    # through WeightLoader + WeightApplier (real mflux-format detection and
+    # stored-quantization restore), and require the parameter trees to match
+    # exactly. No downloads, no tokenizers, no image generation.
+
+    @staticmethod
+    def save_and_reload_expecting_identical_weights(
+        weight_definition,
+        make_components,
+        base_path: Path,
+        bits: int = 8,
+    ) -> None:
+        saved = make_components()
+        # Many layers init deterministically (zeros/ones), which would let a
+        # value-corrupting bug hide behind trivially-equal tensors; give every
+        # parameter distinct random values so the equality check below has teeth.
+        TinyCheckpointRoundtrip._randomize(saved, seed=0)
+        TinyCheckpointRoundtrip._quantize(saved, weight_definition, bits)
+        ModelSaver.save_model(
+            model=TinyCheckpointRoundtrip._as_model(saved, weight_definition),
+            bits=bits,
+            base_path=str(base_path),
+            weight_definition=weight_definition,
+        )
+
+        loaded = WeightLoader.load(weight_definition=weight_definition, model_path=str(base_path))
+        assert loaded.meta_data.quantization_level == bits
+        assert loaded.meta_data.mflux_version == VersionUtil.get_mflux_version()
+
+        # A different seed guarantees the fresh modules start from different
+        # weights, so equality below proves the values came from disk.
+        fresh = make_components()
+        TinyCheckpointRoundtrip._randomize(fresh, seed=1)
+        applied_bits = WeightApplier.apply_and_quantize(
+            weights=loaded,
+            models=fresh,
+            quantize_arg=None,
+            weight_definition=weight_definition,
+        )
+        assert applied_bits == bits
+
+        for name, saved_module in saved.items():
+            saved_weights = dict(tree_flatten(saved_module.parameters()))
+            fresh_weights = dict(tree_flatten(fresh[name].parameters()))
+            assert saved_weights.keys() == fresh_weights.keys(), f"{name}: key sets differ"
+            for key, value in saved_weights.items():
+                assert mx.array_equal(value, fresh_weights[key]), f"{name}.{key}: values differ after reload"
+
+    @staticmethod
+    def _randomize(components: dict[str, nn.Module], seed: int) -> None:
+        mx.random.seed(seed)
+        for module in components.values():
+            randomized = []
+            for key, value in tree_flatten(module.parameters()):
+                if mx.issubdtype(value.dtype, mx.floating):
+                    randomized.append((key, mx.random.normal(value.shape).astype(value.dtype)))
+                elif mx.issubdtype(value.dtype, mx.integer):
+                    # e.g. Ideogram 4's Fp8Linear stores fp8 weights as uint8
+                    randomized.append((key, mx.random.randint(0, 255, value.shape).astype(value.dtype)))
+            module.update(tree_unflatten(randomized))
+
+    @staticmethod
+    def _quantize(components: dict[str, nn.Module], weight_definition, bits: int) -> None:
+        group_size = getattr(weight_definition, "quantization_group_size", 64)
+        for module in components.values():
+            nn.quantize(
+                module,
+                group_size=group_size,
+                bits=bits,
+                class_predicate=lambda path, m: weight_definition.quantization_predicate(path, m),
+            )
+
+    @staticmethod
+    def _as_model(components: dict[str, nn.Module], weight_definition):
+        # ModelSaver reads components as attributes named by the definition
+        # (model_attr, falling back to the component name) — same shape as the
+        # real model objects whose save_model() delegates to ModelSaver.
+        class _ComponentHolder:
+            pass
+
+        model = _ComponentHolder()
+        for component in weight_definition.get_components():
+            setattr(model, component.model_attr or component.name, components[component.name])
+        return model

--- a/tests/model_saving/tiny_checkpoint_helper.py
+++ b/tests/model_saving/tiny_checkpoint_helper.py
@@ -1,5 +1,7 @@
+import contextlib
 from pathlib import Path
 from typing import Callable
+from unittest import mock
 
 import mlx.core as mx
 from mlx import nn
@@ -37,6 +39,7 @@ class TinyCheckpointRoundtrip:
         make_components: Callable[[], dict[str, nn.Module]],
         base_path: Path,
         bits: int = 8,
+        tensors_per_shard: int | None = None,
     ) -> None:
         saved = make_components()
         # Many layers init deterministically (zeros/ones), which would let a
@@ -44,12 +47,23 @@ class TinyCheckpointRoundtrip:
         # parameter distinct random values so the equality check below has teeth.
         TinyCheckpointRoundtrip._randomize(saved, seed=0)
         TinyCheckpointRoundtrip._quantize(saved, weight_definition, bits)
-        ModelSaver.save_model(
-            model=TinyCheckpointRoundtrip._as_model(saved, weight_definition),
-            bits=bits,
-            base_path=str(base_path),
-            weight_definition=weight_definition,
-        )
+        # ModelSaver._split_weights splits by size (>= 1 GB), so tiny tensors always
+        # land in a single shard and the multi-shard save/load paths (index.json,
+        # weight_map, cross-shard ordering) go unexercised. tensors_per_shard forces
+        # a shard boundary every N tensors so those paths exist at test size.
+        with TinyCheckpointRoundtrip._forced_sharding(tensors_per_shard):
+            ModelSaver.save_model(
+                model=TinyCheckpointRoundtrip._as_model(saved, weight_definition),
+                bits=bits,
+                base_path=str(base_path),
+                weight_definition=weight_definition,
+            )
+        if tensors_per_shard is not None:
+            shard_files = list(base_path.rglob("*.safetensors"))
+            component_count = len(weight_definition.get_components())
+            assert len(shard_files) > component_count, (
+                f"expected multi-shard components, got {len(shard_files)} shards for {component_count} components"
+            )
 
         loaded = WeightLoader.load(weight_definition=weight_definition, model_path=str(base_path))
         assert loaded.meta_data.quantization_level == bits
@@ -73,6 +87,17 @@ class TinyCheckpointRoundtrip:
             assert saved_weights.keys() == fresh_weights.keys(), f"{name}: key sets differ"
             for key, value in saved_weights.items():
                 assert mx.array_equal(value, fresh_weights[key]), f"{name}.{key}: values differ after reload"
+
+    @staticmethod
+    def _forced_sharding(tensors_per_shard: int | None):
+        if tensors_per_shard is None:
+            return contextlib.nullcontext()
+
+        def _split_every_n(weights: dict, max_file_size_gb: int = 2) -> list[dict]:
+            items = list(weights.items())
+            return [dict(items[i : i + tensors_per_shard]) for i in range(0, len(items), tensors_per_shard)]
+
+        return mock.patch.object(ModelSaver, "_split_weights", staticmethod(_split_every_n))
 
     @staticmethod
     def _randomize(components: dict[str, nn.Module], seed: int) -> None:

--- a/tests/model_saving/tiny_checkpoint_helper.py
+++ b/tests/model_saving/tiny_checkpoint_helper.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Callable
 
 import mlx.core as mx
 from mlx import nn
@@ -14,7 +15,7 @@ class TinyVAEStandIn(nn.Module):
     # The real VAEs are fixed-size (~170M param) architectures with no dimension
     # knobs. ModelSaver/WeightLoader treat every component as an opaque parameter
     # tree, so a small module walks the identical save/load code path.
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.conv_in = nn.Conv2d(3, 64, kernel_size=3)
         self.proj = nn.Linear(64, 64)
@@ -27,10 +28,13 @@ class TinyCheckpointRoundtrip:
     # stored-quantization restore), and require the parameter trees to match
     # exactly. No downloads, no tokenizers, no image generation.
 
+    # weight_definition is `type` rather than the src WeightDefinitionType alias:
+    # that TYPE_CHECKING-only union has drifted (it omits ErnieWeightDefinition,
+    # among others), and widening a src type alias is out of scope for tests.
     @staticmethod
     def save_and_reload_expecting_identical_weights(
-        weight_definition,
-        make_components,
+        weight_definition: type,
+        make_components: Callable[[], dict[str, nn.Module]],
         base_path: Path,
         bits: int = 8,
     ) -> None:
@@ -84,7 +88,7 @@ class TinyCheckpointRoundtrip:
             module.update(tree_unflatten(randomized))
 
     @staticmethod
-    def _quantize(components: dict[str, nn.Module], weight_definition, bits: int) -> None:
+    def _quantize(components: dict[str, nn.Module], weight_definition: type, bits: int) -> None:
         group_size = getattr(weight_definition, "quantization_group_size", 64)
         for module in components.values():
             nn.quantize(
@@ -95,7 +99,7 @@ class TinyCheckpointRoundtrip:
             )
 
     @staticmethod
-    def _as_model(components: dict[str, nn.Module], weight_definition):
+    def _as_model(components: dict[str, nn.Module], weight_definition: type):
         # ModelSaver reads components as attributes named by the definition
         # (model_attr, falling back to the component name) — same shape as the
         # real model objects whose save_model() delegates to ModelSaver.


### PR DESCRIPTION
## What

**Proposal for discussion, anchored with a working implementation example** — not a finished feature. This PR demonstrates a *tiny-fixture* testing workflow and asks whether the project wants to adopt it; the two tests are the concrete artifact to react to.

**The gap**: the save→load seam (`ModelSaver` shard/index/metadata writing → `WeightLoader` mflux-format detection and stored-quantization restore → `WeightApplier`) is currently only exercised by `@pytest.mark.slow` tests that download 14–26 GB checkpoints, so it has zero PR-CI coverage.

**The workflow demonstrated**: build *real* model component classes at tiny (multiple-of-64) dimensions, randomize every parameter, quantize, save through the real `ModelSaver`, reload through the real `WeightLoader` + `WeightApplier`, and require exact parameter-tree equality. No downloads, no tokenizers, no image generation — both tests pass under `HF_HUB_OFFLINE=1` in ~0.1s each.

The two demo models were chosen so reviewers can diff each new test side-by-side against its existing slow twin covering the same seam:

| New fast test | Existing slow twin | Cost delta |
|---|---|---|
| `test_tiny_model_saving_ideogram4.py` | `test_model_saving_ideogram4.py` | 26 GB download → 0.1s hermetic |
| `test_tiny_model_saving_ernie_image.py` | `test_model_saving_ernie_image.py` | full checkpoint → 0.06s hermetic |

Design decisions to weigh in on:

- **Real classes for parameterized components** (transformers, text encoders): this caught real model-specific structure — Ideogram 4's `Fp8Linear` stores fp8 weights as uint8, now covered by the roundtrip.
- **Tiny stand-in for VAEs**: the real VAEs are fixed ~170M-param architectures with no dimension knobs; the save/load pipeline is tree-based and class-agnostic, so a small module walks the identical code path.
- **Anti-vacuity randomization**: most layers init deterministically (only 1/62 Ideogram 4 transformer tensors differed between seeds before this), so the helper explicitly randomizes all float *and* integer params, and the fresh modules get a *different* randomization before load — verified 100% of tensors differ pre-load, so equality proves the values came from disk.
- **Out of scope, deliberately**: tokenizer save/load, HF-layout key mapping, and generation numerics. Those are the Hub-layout and golden-image seams; the slow tests remain their home.

**If this workflow gets buy-in**, follow-ups could extend it to other models (flux2, qwen-image, z-image) and other seams (LoRA bake-and-strip on save). If reviewers prefer a different shape (e.g. published `tiny-random-*` Hub checkpoints à la transformers/diffusers), happy to discuss tradeoffs — that alternative buys upstream-layout drift detection at the cost of network dependence and artifact maintenance.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default (selector: `-m "not slow and not high_memory_requirement"`, same as `just test`). Only mark `@pytest.mark.slow` or `@pytest.mark.high_memory_requirement` when a test exceeds CI's time or memory budget (typically weight downloads / image generation).
- [x] `ruff check` and `ruff format` are clean (`uv run ruff` uses the version pinned in the dev dependencies of `pyproject.toml`, which is the single source of truth for pre-commit and CI; `pre-commit run -a` covers it locally).
- [ ] `CHANGELOG.md`: entry under `Unreleased` referencing this PR number. *(Held back pending discussion — will add if the proposal is accepted; test-only change otherwise.)*
- [x] Docs updated where behavior changed — README examples/table rows are part of the API contract (see `.cursor/rules/RULE.md`). *(No behavior change; test-only.)*
- [ ] New model: shared config wiring (aliases, default steps, mflux-save dispatch, capabilities, completions), thin CLI entrypoint, and `src/mflux/models/<name>/README.md`. *(N/A)*
- [ ] New/changed CLI: ignored/rejected options declared (`IGNORED_OPTIONS`/`REJECTED_OPTIONS`) and `warn_ignored_options` actually called in `main()` — `mflux-capabilities` must stay truthful. *(N/A)*

## Verification

```
$ HF_HUB_OFFLINE=1 uv run python -m pytest tests/model_saving/ -q
2 passed, 6 deselected in 0.93s        # hermetic: no Hub access

$ uv run python -m pytest -q            # full default suite
1180 passed, 3 skipped, 62 deselected in 4.68s

$ just lint && uv run ty check
All checks passed!
```

Anti-vacuity check (equality assertions have teeth — all tensors differ between the saved and fresh modules before weights are applied):

```
vae: 4/4 tensors differ
conditional_transformer: 62/62 tensors differ
unconditional_transformer: 62/62 tensors differ
text_encoder: 39/39 tensors differ
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added fast validation for saving and reloading quantized ERNIE image checkpoints.
  - Added fast validation for saving and reloading quantized Ideogram 4 checkpoints.
  - Confirmed that 8-bit, multi-shard checkpoint round trips preserve model weights exactly.
  - Added reusable checks for checkpoint metadata, quantization settings, sharding, and component integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces hermetic, quantized save-and-load tests for tiny ERNIE Image and Ideogram 4 component trees.
- Adds reusable parameter randomization, quantization, forced sharding, metadata validation, and exact roundtrip comparison.
- Adds fast ERNIE Image and Ideogram 4 fixtures using reduced model dimensions and a lightweight VAE stand-in.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/model_saving/tiny_checkpoint_helper.py | Adds the shared tiny-checkpoint construction, randomization, forced-sharding, save/load, metadata, and exact-weight verification workflow. |
| tests/model_saving/test_tiny_model_saving_ernie_image.py | Adds a fast quantized ERNIE Image checkpoint roundtrip using reduced real transformer and text-encoder classes. |
| tests/model_saving/test_tiny_model_saving_ideogram4.py | Adds a fast quantized Ideogram 4 checkpoint roundtrip using reduced real transformer and text-encoder classes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Tiny test
    participant S as ModelSaver
    participant D as Checkpoint shards
    participant L as WeightLoader
    participant A as WeightApplier
    T->>T: Build, randomize, and quantize components
    T->>S: save_model(...)
    S->>D: Write metadata and safetensor shards
    T->>L: load(checkpoint path)
    D-->>L: Return stored weights and metadata
    T->>A: Apply loaded weights to fresh components
    A-->>T: Return restored quantization level
    T->>T: Compare parameter trees exactly
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into test/tiny-check..."](https://github.com/mflux-community/mflux/commit/a7ab6e314db31db354c59e9fd01756e4d01ee3ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53576402)</sub>

<!-- /greptile_comment -->