### PR TITLE
Chore: bump CUDA only mlx version to <0.33.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # M-32768 rows come back garbage (silently, no error). Quantized SeedVR2
     # above ~8.4MP output hits it as a noise band across the top of the image.
     "mlx>=0.32.0,<0.33.0; sys_platform=='darwin'",
-    "mlx[cuda13]>=0.30.3,<0.32.0; sys_platform=='linux'",
+    "mlx[cuda13]>=0.30.3,<0.33.0; sys_platform=='linux'",
     "numpy>=2.0.1,<3.0",
     "opencv-python>=4.10.0,<5.0",
     "piexif>=1.1.3,<2.0",


### PR DESCRIPTION
I'm doing some CUDA CI stuff on cloud GPU and this is blocking me...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux CUDA 13 compatibility to support MLX versions below 0.33.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR widens the supported Linux CUDA MLX range to admit 0.32.x releases.
- Changes the Linux `mlx[cuda13]` upper bound from `<0.32.0` to `<0.33.0`.
- Leaves the committed universal lockfile on the old constraint, breaking the repository's locked CI installation.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until uv.lock is regenerated so the locked CI installation accepts the changed Linux MLX constraint.

The manifest and universal lockfile now encode different Linux MLX dependency bounds, while CI explicitly requires a current lockfile.

**Files Needing Attention:** pyproject.toml, uv.lock

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Widens the Linux MLX CUDA dependency range, but the corresponding uv.lock metadata was not regenerated. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
pyproject.toml:35
**Stale Linux MLX lock constraint**

When CI runs `uv sync --all-extras --locked`, `pyproject.toml` allows Linux MLX versions below 0.33.0 while `uv.lock` still records the previous `<0.32.0` constraint, causing the locked installation and tests job to abort.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["bump mlx version to &lt;0.33.0 for CUDA"](https://github.com/mflux-community/mflux/commit/8412a3c2a52aedf1bac70e6badf81931c7dfab80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53883354)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->