### PR TITLE
docs: fix Ideogram 4 local model flag

### DIFF
--- a/src/mflux/models/ideogram4/README.md
+++ b/src/mflux/models/ideogram4/README.md
@@ -325,10 +325,10 @@ mflux-save --model ideogram-4-fp8 -q 8 --path ideogram-4-mflux-q8
 mflux-save --model ideogram-4-fp8 -q 4 --path ideogram-4-mflux-q4
 ```
 
-Generate from a saved checkpoint with `--model-path`, which needs no Hugging Face access once the conversion is done:
+Generate from a saved checkpoint with `--model`, which needs no Hugging Face access once the conversion is done:
 
 ```sh
-mflux-generate-ideogram4 --model-path ideogram-4-mflux-q4 --prompt-file caption.json
+mflux-generate-ideogram4 --model ideogram-4-mflux-q4 --prompt-file caption.json
 ```
 
 | Checkpoint | On disk |


### PR DESCRIPTION
## Summary

- replace the stale `--model-path` option in the Ideogram 4 quantized-checkpoint example
- use the current unified `--model` option for loading a local checkpoint

## Verification

- `git diff --check`
- documentation-only change; tests not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the quantized-checkpoint generation example to use the current `--model` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects the Ideogram 4 saved-checkpoint example to use the unified `--model` option, which accepts the locally saved checkpoint path and supports offline loading.

- Replaces the stale `--model-path` option in the explanatory text.
- Updates the corresponding generation command to pass the checkpoint through `--model`.

<h3>Confidence Score: 5/5</h3>

The documentation-only correction appears safe to merge.

The updated command matches the current parser contract, and an existing local checkpoint is resolved without requiring Hugging Face access.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/ideogram4/README.md | The documentation now uses the CLI option that correctly routes non-built-in model values to the local checkpoint loader. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix Ideogram 4 local model flag"](https://github.com/mflux-community/mflux/commit/dc72cb031a1392b82af40cb79dc66b8fc2fd307d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53904200)</sub>

<!-- /greptile_comment -->