### PR TITLE
fix: restore the dimensions, negative prompt and init images a metadata sidecar records

### DIFF
--- a/src/mflux/cli/completions/generator.py
+++ b/src/mflux/cli/completions/generator.py
@@ -65,13 +65,7 @@ class CompletionGenerator:
             parser.add_general_arguments()
             parser.add_model_arguments(require_model_arg=False)
             parser.add_lora_arguments()
-            parser.add_argument(
-                "--image-paths",
-                type=Path,
-                nargs="+",
-                required=True,
-                help="Local paths to one or more init images. For single image editing, provide one path. For multiple image editing, provide multiple paths.",
-            )
+            parser.add_image_paths_arguments()
             parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
             parser.add_output_arguments()
 
@@ -154,7 +148,7 @@ class CompletionGenerator:
             parser.add_model_arguments(require_model_arg=False)
             parser.add_lora_arguments()
             parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
-            parser.add_argument("--image-paths", type=Path, nargs="+", required=True, help="Local paths to init images")
+            parser.add_image_paths_arguments()
             parser.add_output_arguments()
 
         elif command == "mflux-generate-fibo":

--- a/src/mflux/cli/parser/parsers.py
+++ b/src/mflux/cli/parser/parsers.py
@@ -97,6 +97,7 @@ class CommandLineParser(argparse.ArgumentParser):
         self.supports_lora = False
         self.require_model_arg = True
         self.require_init_image = False
+        self.require_image_paths = False
         self.default_model = None
 
     def add_general_arguments(self) -> None:
@@ -187,6 +188,13 @@ class CommandLineParser(argparse.ArgumentParser):
         self.add_argument("--image", dest="image", nargs="+", default=None, metavar=("PATH", "STRENGTH"), help=f"Init image as an atomic PATH with optional STRENGTH (default {ui_defaults.IMAGE_STRENGTH}): --image photo.jpg 0.6. Preferred over --image-path/--image-strength.")
         self.add_argument("--image-path", type=Path, required=False, default=None, help="[DEPRECATED: use --image] Local path to init image")
         self.add_argument("--image-strength", type=float, required=False, default=ui_defaults.IMAGE_STRENGTH, help=f"[DEPRECATED: use --image] Controls how strongly the init image influences the output image. A value of 0.0 means no influence. (Default is {ui_defaults.IMAGE_STRENGTH})")
+
+    def add_image_paths_arguments(self, required: bool = True) -> None:
+        # The requirement is enforced after parsing (see parse_args) rather than by argparse:
+        # argparse checks required= before parse_args reaches the metadata block, so an edit
+        # CLI exited 2 on images a --config-from-metadata sidecar was carrying.
+        self.require_image_paths = required
+        self.add_argument("--image-paths", type=Path, nargs="+", default=None, help="Local paths to one or more init images. For single image editing, provide one path. For multiple image editing, provide multiple paths.")
 
     def add_batch_image_generator_arguments(self) -> None:
         self.add_argument("--batch-prompts-file", type=Path, required=True, default=argparse.SUPPRESS, help="Local path for a file that holds a batch of prompts.")
@@ -395,6 +403,7 @@ class CommandLineParser(argparse.ArgumentParser):
             self.error("--model must be specified when using --path")
 
         lora_paths_from_metadata = False
+        image_paths_from_metadata = False
 
         if getattr(namespace, "config_from_metadata", False):
             prior_gen_metadata = json.load(namespace.config_from_metadata.open("rt"))
@@ -409,6 +418,17 @@ class CommandLineParser(argparse.ArgumentParser):
 
             if namespace.prompt is None:
                 namespace.prompt = prior_gen_metadata.get("prompt", None)
+
+            # Every run records the size it generated at and the negative prompt it used, but
+            # neither was ever read back: a sidecar-only rerun regenerated at the 1024x1024
+            # default (or at the init image's own size on the scale-factor CLIs) and with the
+            # negative prompt dropped, which on a CFG model is a different image entirely.
+            if hasattr(namespace, "negative_prompt") and not self._option_was_provided("--negative-prompt"):
+                namespace.negative_prompt = prior_gen_metadata.get("negative_prompt") or namespace.negative_prompt
+            if hasattr(namespace, "height") and not self._option_was_provided("--height"):
+                namespace.height = prior_gen_metadata.get("height") or namespace.height
+            if hasattr(namespace, "width") and not self._option_was_provided("--width"):
+                namespace.width = prior_gen_metadata.get("width") or namespace.width
 
             # all configs from the metadata config defers to any explicitly defined args
             guidance_default = self.get_default("guidance")
@@ -445,6 +465,10 @@ class CommandLineParser(argparse.ArgumentParser):
 
             if hasattr(namespace, "image_path") and namespace.image_path is None:
                 namespace.image_path = prior_gen_metadata.get("image_path", None)
+
+            if hasattr(namespace, "image_paths") and namespace.image_paths is None:
+                namespace.image_paths = [Path(p) for p in prior_gen_metadata.get("image_paths") or []] or None
+                image_paths_from_metadata = namespace.image_paths is not None
 
             if hasattr(namespace, "mask_path") and namespace.mask_path is None:
                 namespace.mask_path = (
@@ -486,6 +510,15 @@ class CommandLineParser(argparse.ArgumentParser):
 
         if self.require_init_image and getattr(namespace, "image_path", None) is None:
             self.error("An init image is required. Provide one with --image PATH [STRENGTH] (e.g. --image photo.jpg 0.8).")
+
+        if self.require_image_paths and not getattr(namespace, "image_paths", None):
+            self.error("At least one init image is required. Provide one with --image-paths PATH [PATH ...] (e.g. --image-paths photo.jpg).")
+
+        if image_paths_from_metadata and (missing := [path for path in namespace.image_paths if not path.exists()]):
+            # A sidecar records the resolved absolute path, so one carried between machines
+            # fails on an argument the user never typed — and, without this, only after the
+            # model has loaded, since nothing opens the file until dimension resolution.
+            self.error(f"Init image not found: {', '.join(str(path) for path in missing)}\nTip: that path came from {namespace.config_from_metadata}. Pass --image-paths PATH [PATH ...] to use your own copy.")  # fmt: off
 
         if self.supports_image_generation and namespace.seed is None and namespace.auto_seeds > 0:
             # choose N unique int seeds in the range of  0 < value < 1 billion

--- a/src/mflux/models/common/README.md
+++ b/src/mflux/models/common/README.md
@@ -459,6 +459,8 @@ mflux-generate-z-image-turbo \
   --prompt "Same composition, warmer light"
 ```
 
+Anything the sidecar recorded is restored — model, prompt and negative prompt, seed, steps, guidance, quantization, dimensions, LoRAs, and the init images of the edit CLIs — and anything named on the command line wins over it, option by option. Since the sidecar can supply the init images, `mflux-generate-qwen-edit` and `mflux-generate-flux2-edit` accept `--config-from-metadata` on its own, without `--image-paths`.
+
 <details>
 <summary>Python API</summary>
 

--- a/src/mflux/models/flux2/cli/flux2_edit_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_edit_generate.py
@@ -30,7 +30,7 @@ def build_parser() -> CommandLineParser:
     parser.add_general_arguments()
     parser.add_model_arguments(require_model_arg=False, default_model=DEFAULT_MODEL)
     parser.add_lora_arguments()
-    parser.add_argument("--image-paths", type=Path, nargs="+", required=True, help="Local paths to one or more init images. For single image editing, provide one path. For multiple image editing, provide multiple paths.")  # fmt: off
+    parser.add_image_paths_arguments()
     parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
     parser.add_output_arguments()
     return parser
@@ -40,7 +40,10 @@ def main():
     parser = build_parser()
     args = parser.parse_args()
 
-    if getattr(args, "negative_prompt", ""):
+    # Keyed on the option, not on the value: a --config-from-metadata sidecar written by a
+    # CFG model restores a negative prompt the user never typed, and rejecting the rerun for
+    # it would blame them for an argument that is not on the command line.
+    if CommandLineParser._option_was_provided("--negative-prompt"):
         parser.error("--negative-prompt is not supported for FLUX.2. Focus on describing what you want.")
 
     model_name = args.model or DEFAULT_MODEL

--- a/src/mflux/models/flux2/cli/flux2_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_generate.py
@@ -39,7 +39,10 @@ def main():
     parser = build_parser()
     args = parser.parse_args()
 
-    if getattr(args, "negative_prompt", ""):
+    # Keyed on the option, not on the value: a --config-from-metadata sidecar written by a
+    # CFG model restores a negative prompt the user never typed, and rejecting the rerun for
+    # it would blame them for an argument that is not on the command line.
+    if CommandLineParser._option_was_provided("--negative-prompt"):
         parser.error("--negative-prompt is not supported for FLUX.2. Focus on describing what you want.")
 
     model_name = args.model or DEFAULT_MODEL

--- a/src/mflux/models/qwen/cli/qwen_image_edit_generate.py
+++ b/src/mflux/models/qwen/cli/qwen_image_edit_generate.py
@@ -20,7 +20,7 @@ def build_parser() -> CommandLineParser:
     parser.add_model_arguments(require_model_arg=False, default_model=DEFAULT_MODEL)
     parser.add_lora_arguments()
     parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
-    parser.add_argument("--image-paths", type=Path, nargs="+", required=True, help="Local paths to one or more init images. For single image editing, provide one path. For multiple image editing, provide multiple paths.")  # fmt: off
+    parser.add_image_paths_arguments()
     parser.add_output_arguments()
     return parser
 

--- a/tests/arg_parser/test_metadata_roundtrip_restore.py
+++ b/tests/arg_parser/test_metadata_roundtrip_restore.py
@@ -1,0 +1,168 @@
+# A metadata sidecar records the size a run generated at, the negative prompt it used and
+# the init images an edit CLI was pointed at, but --config-from-metadata never read any of
+# them back: a sidecar-only rerun regenerated at the wrong size with no negative prompt,
+# and on the edit CLIs argparse rejected it outright, before the restore block ever ran.
+
+import json
+import sys
+
+import pytest
+
+from mflux.models.flux2.cli import flux2_edit_generate
+from mflux.models.krea2.cli import krea2_generate
+from mflux.models.qwen.cli import qwen_image_edit_generate
+from mflux.models.z_image.cli import z_image_generate
+
+ELSEWHERE = "/Users/someone-else/photos/cat.png"
+
+SCALE_FACTOR_CLIS = [krea2_generate, qwen_image_edit_generate, flux2_edit_generate]
+EDIT_CLIS = [qwen_image_edit_generate, flux2_edit_generate]
+
+
+@pytest.fixture
+def source_image(tmp_path):
+    def make(name: str) -> str:
+        path = tmp_path / name
+        path.touch()
+        return str(path)
+
+    return make
+
+
+@pytest.fixture
+def sidecar(tmp_path, source_image):
+    def write(**overrides):
+        metadata = {
+            "model": "krea-2",
+            "prompt": "a red cube",
+            "seed": 7,
+            "steps": 8,
+            "height": 1536,
+            "width": 768,
+            "negative_prompt": "blurry, watermark",
+            "image_paths": [source_image("first.png"), source_image("second.png")],
+        }
+        metadata.update(overrides)
+        path = tmp_path / f"prior-{len(list(tmp_path.glob('prior-*.json')))}.metadata.json"
+        path.write_text(json.dumps(metadata))
+        return path
+
+    return write
+
+
+@pytest.fixture
+def parse(monkeypatch):
+    def run(cli, *argv: str):
+        monkeypatch.setattr(sys, "argv", ["prog", *argv])
+        return cli.build_parser().parse_args()
+
+    return run
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("cli", SCALE_FACTOR_CLIS, ids=lambda cli: cli.__name__.rsplit(".", 1)[-1])
+def test_the_sidecar_supplies_the_size_it_generated_at(parse, sidecar, cli):
+    # These CLIs default to "auto", which without an init image falls through to 1024x1024.
+    args = parse(cli, "--config-from-metadata", str(sidecar()))
+    assert (args.width, args.height) == (768, 1536)
+
+
+@pytest.mark.fast
+def test_the_sidecar_supplies_the_size_on_a_fixed_dimension_cli(parse, sidecar):
+    # z-image has no scale factors: its default is the literal 1024 that reruns came out at.
+    args = parse(z_image_generate, "--config-from-metadata", str(sidecar()))
+    assert (args.width, args.height) == (768, 1536)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("cli", [krea2_generate, z_image_generate], ids=["krea2", "z-image"])
+def test_the_sidecar_supplies_the_negative_prompt(parse, sidecar, cli):
+    args = parse(cli, "--config-from-metadata", str(sidecar()))
+    assert args.negative_prompt == "blurry, watermark"
+
+
+@pytest.mark.fast
+def test_the_command_line_overrides_the_sidecar_one_dimension_at_a_time(parse, sidecar):
+    args = parse(krea2_generate, "--config-from-metadata", str(sidecar()), "--height", "512")
+    assert (args.width, args.height) == (768, 512)
+
+
+@pytest.mark.fast
+def test_a_negative_prompt_on_the_command_line_replaces_the_sidecars(parse, sidecar):
+    args = parse(krea2_generate, "--config-from-metadata", str(sidecar()), "--negative-prompt", "mine")
+    assert args.negative_prompt == "mine"
+
+
+@pytest.mark.fast
+def test_a_sidecar_without_the_keys_leaves_the_defaults_alone(parse, sidecar):
+    path = sidecar(height=None, width=None, negative_prompt=None)
+    args = parse(z_image_generate, "--config-from-metadata", str(path))
+    assert (args.width, args.height) == (1024, 1024)
+    assert args.negative_prompt == ""
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("cli", EDIT_CLIS, ids=["qwen-edit", "flux2-edit"])
+def test_the_sidecar_supplies_the_init_images(parse, sidecar, cli):
+    # argparse checks required= before parse_args reaches the metadata block, so this used
+    # to exit 2 on images the sidecar was carrying all along.
+    path = sidecar()
+    expected = json.loads(path.read_text())["image_paths"]
+    args = parse(cli, "--config-from-metadata", str(path))
+    assert [str(image) for image in args.image_paths] == expected
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("cli", EDIT_CLIS, ids=["qwen-edit", "flux2-edit"])
+def test_init_images_on_the_command_line_replace_the_sidecars(parse, sidecar, source_image, cli):
+    mine = source_image("mine.png")
+    args = parse(cli, "--config-from-metadata", str(sidecar()), "--image-paths", mine)
+    assert [str(image) for image in args.image_paths] == [mine]
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("cli", EDIT_CLIS, ids=["qwen-edit", "flux2-edit"])
+def test_an_edit_cli_still_requires_init_images_from_somewhere(parse, capsys, cli):
+    with pytest.raises(SystemExit) as exit_info:
+        parse(cli, "--prompt", "a red cube")
+    assert exit_info.value.code == 2
+    assert "--image-paths" in capsys.readouterr().err
+
+
+@pytest.mark.fast
+def test_a_sidecar_init_image_that_is_missing_here_names_the_sidecar(parse, sidecar, capsys):
+    # Sidecars record the absolute path the generating machine resolved. Without this the
+    # rerun loaded the whole model first and then died on a bare FileNotFoundError, since
+    # nothing opens the file until dimension resolution.
+    path = sidecar(image_paths=[ELSEWHERE])
+    with pytest.raises(SystemExit) as exit_info:
+        parse(qwen_image_edit_generate, "--config-from-metadata", str(path))
+    assert exit_info.value.code == 2
+    stderr = capsys.readouterr().err
+    assert ELSEWHERE in stderr
+    assert str(path) in stderr
+
+
+@pytest.mark.fast
+def test_flux2_rejects_a_negative_prompt_that_was_actually_typed(monkeypatch, capsys, source_image):
+    monkeypatch.setattr(sys, "argv", ["prog", "--prompt", "a red cube", "--image-paths", source_image("a.png"), "--negative-prompt", "blurry"])  # fmt: off
+    with pytest.raises(SystemExit) as exit_info:
+        flux2_edit_generate.main()
+    assert exit_info.value.code == 2
+    assert "not supported for FLUX.2" in capsys.readouterr().err
+
+
+@pytest.mark.fast
+def test_flux2_does_not_blame_the_user_for_a_sidecars_negative_prompt(monkeypatch, sidecar):
+    # FLUX.2 has no negative branch, but the sidecar of a CFG model carries one and the
+    # rerun must not be rejected for an argument that is nowhere on the command line.
+    reached_model_load = RuntimeError("reached model load")
+
+    def explode(*args, **kwargs):
+        raise reached_model_load
+
+    monkeypatch.setattr(flux2_edit_generate, "Flux2KleinEdit", explode)
+    monkeypatch.setattr(sys, "argv", ["prog", "--config-from-metadata", str(sidecar(model="flux2-klein-4b"))])
+    with pytest.raises(RuntimeError) as exit_info:
+        flux2_edit_generate.main()
+    assert exit_info.value is reached_model_load


### PR DESCRIPTION
Takes the **Embedded `negative_prompt`/`height`/`width`/`image_paths` never restored** checkbox from #577.

### Scenario — a sidecar rerun comes out the wrong size

1) User generates at 1536x768 with a negative prompt and `--metadata`.
2) User reruns with `--config-from-metadata image.metadata.json` and a new prompt.
3) The image comes out 1024x1024 with no negative prompt.

`generated_image.py` embeds `height`, `width` and `negative_prompt` on every run, but the restore block never read them back. On the fixed-dimension CLIs (z-image) the rerun falls to the 1024 default; on the scale-factor CLIs (krea2, z-image-turbo, qwen, flux2) `--height/--width` default to `auto`, which without an init image also lands on 1024x1024. Dropping the negative prompt is the bigger one: on a CFG model that is a different image, not a differently-sized one.

**Fix:** restore all three behind `_option_was_provided` guards, so the command line still wins option by option (`-C sidecar --height 512` keeps the sidecar's width).

### Scenario — an edit CLI cannot round-trip at all

1) User generates with `mflux-generate-qwen-edit --image-paths a.png b.png --metadata`.
2) User reruns with `--config-from-metadata image.metadata.json`.
3) `error: the following arguments are required: --image-paths`, exit 2.

`--image-paths` was declared `required=True`, and argparse enforces that before `parse_args` reaches the metadata block — so the flag was demanded for images the sidecar was carrying all along.

**Fix:** a shared `add_image_paths_arguments()` on `CommandLineParser` registers the flag without argparse's `required`, records the requirement on the parser, and `parse_args` enforces it after the restore — the same shape `require_init_image` already uses for `--image`. `image_paths` is restored when the command line named none. Both edit CLIs and the two hand-rolled copies in the completions generator now go through it.

### Two additions to the scope

- **Restored init images are checked for existence**, with an error naming the sidecar. A sidecar records the generating machine's absolute paths, so one carried between machines has dead ones — and relaxing `required` means it now sails past the parser, loads the whole model, and dies on a bare `FileNotFoundError`, because nothing opens the file until dimension resolution. This mirrors what #619 landed for restored LoRA paths. Happy to drop it if the asymmetry with the unvalidated singular `image_path` restore is worse than the traceback.
- **The FLUX.2 CLIs now reject `--negative-prompt` on the option rather than on the value.** `flux2_generate`/`flux2_edit_generate` error on a truthy `args.negative_prompt`; once a sidecar can restore one, a rerun of any CFG-model sidecar would exit with "not supported for FLUX.2" over an argument that is nowhere on the command line. Keyed on `_option_was_provided`, a typed flag still errors and a restored one is simply unused. (Side effect: `--negative-prompt ""` now errors too, where before the empty value slipped through.)

### Not in scope

`redux_image_paths` is embedded and never restored either, but as `str(list_of_paths)` — it does not round-trip in the first place, and `mflux-generate-redux` does not accept `--config-from-metadata`, so there is no hole to fall into yet.

### Verification

- 18 new fast tests in `tests/arg_parser/test_metadata_roundtrip_restore.py`: restore and per-option override for all four keys, across a fixed-dimension CLI and a scale-factor one; sidecar-only parse on both edit CLIs; the requirement still firing when no images exist anywhere; the dead-path error naming the sidecar; and both sides of the FLUX.2 negative-prompt guard.
- `just lint`, `just typecheck`, `just test-fast` all clean. One unrelated pre-existing failure, `tests/pid_decoder/test_gemma2_shapes.py::test_gemma2_model_is_causal` — NaNs in the causal-mask assertion, only in a full-suite run, and it reproduces identically on a clean `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata-based configuration now restores prompts, dimensions, generation settings, LoRAs, and edit images.
  * FLUX.2 Edit and Qwen Edit can reuse metadata without manually specifying image paths.
  * Command-line options take precedence over restored metadata.

* **Bug Fixes**
  * Improved validation and error messages for missing metadata-referenced images.
  * Metadata-restored negative prompts are no longer incorrectly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores dimensions, negative prompts, and edit-image paths from generation metadata while preserving option-by-option command-line precedence.
- Defers edit-image requiredness until after metadata restoration and validates restored paths.
- Prevents metadata-restored negative prompts from being mistaken for unsupported FLUX.2 command-line options.
- Updates completion parsers, documentation, and metadata round-trip coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code defect identified.

Repository-produced sidecars use the shapes expected by the new restoration logic, explicit command-line values retain precedence, required edit images remain enforced after restoration, and restored paths are checked before model loading.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/cli/parser/parsers.py | Adds metadata restoration, deferred plural-image validation, and missing-path diagnostics without an identified contract violation. |
| src/mflux/models/flux2/cli/flux2_edit_generate.py | Uses the shared image-path parser and rejects negative prompts only when the option was explicitly supplied. |
| src/mflux/models/flux2/cli/flux2_generate.py | Aligns unsupported negative-prompt validation with explicit command-line usage. |
| src/mflux/models/qwen/cli/qwen_image_edit_generate.py | Adopts deferred image-path requiredness so metadata-only edit reruns can parse. |
| tests/arg_parser/test_metadata_roundtrip_restore.py | Covers restoration, per-option precedence, edit-image requirements, missing paths, and FLUX.2 validation behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Parse command-line options] --> B{Metadata sidecar supplied?}
    B -- No --> E[Validate required image paths]
    B -- Yes --> C[Load recorded dimensions, negative prompt, and image paths]
    C --> D[Keep explicitly supplied CLI values]
    D --> E
    E --> F{Restored image paths exist?}
    F -- No --> G[Report sidecar path error]
    F -- Yes --> H[Continue generation or editing]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: restore the dimensions, negative pr..."](https://github.com/mflux-community/mflux/commit/92a1df0417e29bdb4a248058e1a714c9b989c3d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54152798)</sub>

<!-- /greptile_comment -->