### PR TITLE
chore: stop coderabbit asking for docstrings the style rules forbid

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,16 @@ reviews:
     drafts: false
     base_branches:
       - main
+  # This repo's code style forbids docstrings (.cursor/rules/RULE.md, "Code style"), so
+  # both docstring mechanisms are off: the finishing touch that opens a follow-up PR adding
+  # them, and the coverage check that warns for falling below a threshold we never want to
+  # meet. Quoted "off" on purpose — bare off is a YAML boolean, and this field is a string.
+  finishing_touches:
+    docstrings:
+      enabled: false
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
   path_filters:
     # Skip binaries, generated images, and golden reference outputs.
     - "!**/*.png"


### PR DESCRIPTION
`.cursor/rules/RULE.md` ("Code style") says **"Avoid docstrings; prefer clear naming and focused helpers."** CodeRabbit ships both of its docstring mechanisms on by default, so every PR here gets nudged toward the opposite:

- `finishing_touches.docstrings` — the 📝 Generate docstrings checkbox, which opens a follow-up PR adding them.
- `pre_merge_checks.docstrings` — a coverage check that defaults to `warning` at anything under 80%, a bar this project does not want to clear.

Turning both off, repo-wide, which is what the rule already says.

CodeRabbit suggested this snippet itself on #632 ([comment](https://github.com/mflux-community/mflux/pull/632#issuecomment-5321035247)) — one deviation from its wording: `mode` is quoted. Bare `off` is a YAML 1.1 boolean, and the schema types that field as a string enum of `off`/`warning`/`error`, so the unquoted form is invalid config:

```
$ jsonschema.validate(cfg, schema.v2.json)
mode: "off"  -> VALID
mode: off    -> False is not of type 'string'
```

Verified with `schema.v2.json` (the one referenced by the file's own `yaml-language-server` line): the committed file validates clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review configuration to disable docstring finishing touches and pre-merge checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns CodeRabbit with the repository’s no-docstrings policy by disabling automated docstring generation and its pre-merge coverage check.
- Disables the docstring finishing-touch follow-up.
- Disables the docstring coverage check using the required quoted `"off"` enum value.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the new configuration is valid and consistently implements the repository’s documented no-docstrings policy.

The settings use the expected CodeRabbit nesting and value types, including quoting the string-valued mode, and no blocking or non-blocking defect remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .coderabbit.yaml | Adds valid repository-wide settings that disable both CodeRabbit docstring mechanisms without affecting runtime code. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: stop coderabbit asking for docstr..."](https://github.com/mflux-community/mflux/commit/52584973a42d6f1eaff8b05a2c60d4770e0ceaa1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54156101)</sub>

<!-- /greptile_comment -->