### PR TITLE
fix: resolve load_single's weights through PathResolution instead of the hub

### DIFF
--- a/src/mflux/models/common/weights/loading/weight_loader.py
+++ b/src/mflux/models/common/weights/loading/weight_loader.py
@@ -30,18 +30,11 @@ class WeightLoader:
         repo_id: str,
         file_pattern: str = "*.safetensors",
     ) -> LoadedWeights:
-        # Every other weight load goes through PathResolution: a complete cached snapshot is
-        # used without a hub round-trip, a local directory is taken as-is, and a miss gives one
-        # uniform error. Calling snapshot_download straight from here skipped all three, so the
-        # three components loaded this way — the FLUX and Z-Image controlnets and the Lens VAE —
-        # were the only weights in mflux that still needed the hub with everything already cached.
-        #
-        # Only the weight pattern is passed. PathResolution judges a cached snapshot by its
-        # patterns, and two of the three repos have no config.json at the root (the Lens VAE's
-        # FLUX.2-klein-4B keeps its at vae/config.json), so asking for one would mark every
-        # cached copy incomplete and leave those two exactly where they started. Nothing reads
-        # config.json out of this snapshot either: ZImageControlNetConfig.from_pretrained
-        # fetches its own copy and already falls back when the repo has none.
+        # file_pattern is both the download filter and the test PathResolution applies to a
+        # cached snapshot, so it must name safetensors and nothing else. Adding "config.json"
+        # would mark every cached copy of a repo that keeps none at its root incomplete
+        # (FLUX.2-klein-4B, the Lens VAE, keeps its under vae/), and a pattern loose enough to
+        # match a config file would pass a half-downloaded snapshot as complete.
         root_path = PathResolution.resolve(path=repo_id, patterns=[file_pattern])
         if root_path is None:
             raise ValueError(f"No weights location for component '{component.name}': resolved nothing from {repo_id!r}.")  # fmt: off

--- a/src/mflux/models/common/weights/loading/weight_loader.py
+++ b/src/mflux/models/common/weights/loading/weight_loader.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 import mlx.core as mx
 import torch
-from huggingface_hub import snapshot_download
 from mlx.utils import tree_unflatten
 from safetensors.torch import load_file as torch_load_file
 
@@ -31,7 +30,21 @@ class WeightLoader:
         repo_id: str,
         file_pattern: str = "*.safetensors",
     ) -> LoadedWeights:
-        root_path = Path(snapshot_download(repo_id=repo_id, allow_patterns=[file_pattern, "config.json"]))
+        # Every other weight load goes through PathResolution: a complete cached snapshot is
+        # used without a hub round-trip, a local directory is taken as-is, and a miss gives one
+        # uniform error. Calling snapshot_download straight from here skipped all three, so the
+        # three components loaded this way — the FLUX and Z-Image controlnets and the Lens VAE —
+        # were the only weights in mflux that still needed the hub with everything already cached.
+        #
+        # Only the weight pattern is passed. PathResolution judges a cached snapshot by its
+        # patterns, and two of the three repos have no config.json at the root (the Lens VAE's
+        # FLUX.2-klein-4B keeps its at vae/config.json), so asking for one would mark every
+        # cached copy incomplete and leave those two exactly where they started. Nothing reads
+        # config.json out of this snapshot either: ZImageControlNetConfig.from_pretrained
+        # fetches its own copy and already falls back when the repo has none.
+        root_path = PathResolution.resolve(path=repo_id, patterns=[file_pattern])
+        if root_path is None:
+            raise ValueError(f"No weights location for component '{component.name}': resolved nothing from {repo_id!r}.")  # fmt: off
         return WeightLoader.load_single_local(component=component, root_path=root_path)
 
     @staticmethod

--- a/src/mflux/models/lens/variants/txt2img/lens_image.py
+++ b/src/mflux/models/lens/variants/txt2img/lens_image.py
@@ -64,7 +64,9 @@ class LensImage:
         mx.eval(self.transformer.parameters())
 
         vae_component = [c for c in Flux2KleinWeightDefinition.get_components() if c.name == "vae"][0]
-        vae_weights = WeightLoader.load_single(vae_component, VAE_REPO, file_pattern="vae/*")
+        # Names the safetensors, not the whole vae/ directory: the pattern is also what
+        # judges a cached snapshot complete, and "vae/*" is satisfied by a stray config.json.
+        vae_weights = WeightLoader.load_single(vae_component, VAE_REPO, file_pattern="vae/*.safetensors")
         self.vae = Flux2VAE()
         WeightApplier.apply_and_quantize_single(vae_weights, self.vae, vae_component, None)
         mx.eval(self.vae.parameters())

--- a/tests/resolution/test_load_single_path_resolution.py
+++ b/tests/resolution/test_load_single_path_resolution.py
@@ -1,0 +1,115 @@
+# WeightLoader.load_single called snapshot_download directly instead of going through
+# PathResolution, so the three components loaded that way — the FLUX and Z-Image controlnets
+# and the Lens VAE — were the only weights in mflux that still needed the hub when everything
+# was already cached, and the only ones a local directory could not stand in for.
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mflux.models.common.resolution.path_resolution import PathResolution
+from mflux.models.common.weights.loading.weight_definition import ComponentDefinition
+from mflux.models.common.weights.loading.weight_loader import WeightLoader
+
+
+@pytest.fixture
+def component():
+    return ComponentDefinition(name="controlnet", hf_subdir="", loading_mode="mlx_native")
+
+
+@pytest.fixture
+def loaded(monkeypatch):
+    seen = {}
+
+    def record(component, root_path):
+        seen["component"] = component
+        seen["root_path"] = root_path
+        return "weights"
+
+    monkeypatch.setattr(WeightLoader, "load_single_local", record)
+    return seen
+
+
+@pytest.mark.fast
+def test_a_complete_cached_snapshot_is_used_without_the_hub(component, loaded, tmp_path):
+    snapshot = tmp_path / "models--org--model" / "snapshots" / "abc123"
+    snapshot.mkdir(parents=True)
+    (snapshot / "diffusion_pytorch_model.safetensors").touch()
+
+    with patch("mflux.models.common.resolution.path_resolution.HF_HUB_CACHE", str(tmp_path)):
+        with patch("mflux.models.common.resolution.path_resolution.snapshot_download") as download:
+            WeightLoader.load_single(component=component, repo_id="org/model")
+
+    download.assert_not_called()
+    assert loaded["root_path"] == snapshot
+
+
+@pytest.mark.fast
+def test_a_local_directory_stands_in_for_the_repo(component, loaded, tmp_path):
+    (tmp_path / "diffusion_pytorch_model.safetensors").touch()
+
+    with patch("mflux.models.common.resolution.path_resolution.snapshot_download") as download:
+        WeightLoader.load_single(component=component, repo_id=str(tmp_path))
+
+    download.assert_not_called()
+    assert loaded["root_path"] == tmp_path
+
+
+@pytest.mark.fast
+def test_an_uncached_repo_still_downloads(component, loaded, tmp_path):
+    with patch("mflux.models.common.resolution.path_resolution.HF_HUB_CACHE", str(tmp_path / "empty")):
+        with patch("mflux.models.common.resolution.path_resolution.snapshot_download") as download:
+            download.return_value = str(tmp_path / "fetched")
+            WeightLoader.load_single(component=component, repo_id="org/model", file_pattern="vae/*")
+
+    assert download.call_args[1]["repo_id"] == "org/model"
+    assert loaded["root_path"] == tmp_path / "fetched"
+
+
+@pytest.mark.fast
+def test_only_the_weight_pattern_decides_completeness(component, loaded, tmp_path):
+    # The repos behind two of the three components have no config.json at the root — the
+    # Lens VAE's FLUX.2-klein-4B keeps its under vae/ — so carrying the old allow_patterns
+    # over would have marked every cached copy of them incomplete, which is the one case
+    # this change exists to fix.
+    snapshot = tmp_path / "models--org--model" / "snapshots" / "abc123"
+    (snapshot / "vae").mkdir(parents=True)
+    (snapshot / "vae" / "diffusion_pytorch_model.safetensors").touch()
+    (snapshot / "vae" / "config.json").write_text("{}")
+
+    with patch("mflux.models.common.resolution.path_resolution.HF_HUB_CACHE", str(tmp_path)):
+        with patch("mflux.models.common.resolution.path_resolution.snapshot_download") as download:
+            WeightLoader.load_single(component=component, repo_id="org/model", file_pattern="vae/*")
+
+    download.assert_not_called()
+    assert loaded["root_path"] == snapshot
+
+
+@pytest.mark.fast
+def test_the_patterns_reach_path_resolution(component, loaded, tmp_path, monkeypatch):
+    seen = {}
+
+    def record(path, patterns=None):
+        seen["path"], seen["patterns"] = path, patterns
+        return tmp_path
+
+    monkeypatch.setattr(PathResolution, "resolve", record)
+    WeightLoader.load_single(component=component, repo_id="org/model", file_pattern="vae/*")
+    assert seen == {"path": "org/model", "patterns": ["vae/*"]}
+
+
+@pytest.mark.fast
+def test_resolving_nothing_names_the_component(component, monkeypatch):
+    monkeypatch.setattr(PathResolution, "resolve", lambda path, patterns=None: None)
+    with pytest.raises(ValueError, match="controlnet"):
+        WeightLoader.load_single(component=component, repo_id="org/model")
+
+
+@pytest.mark.fast
+def test_weight_loader_no_longer_reaches_for_the_hub_itself():
+    # The direct import is what let this path skip resolution; keep it gone.
+    import mflux.models.common.weights.loading.weight_loader as module
+
+    text = Path(module.__file__).read_text()
+    assert "from huggingface_hub import snapshot_download" not in text

--- a/tests/resolution/test_load_single_path_resolution.py
+++ b/tests/resolution/test_load_single_path_resolution.py
@@ -1,7 +1,5 @@
-# WeightLoader.load_single called snapshot_download directly instead of going through
-# PathResolution, so the three components loaded that way — the FLUX and Z-Image controlnets
-# and the Lens VAE — were the only weights in mflux that still needed the hub when everything
-# was already cached, and the only ones a local directory could not stand in for.
+# load_single resolves through PathResolution rather than calling the hub directly, so a
+# cached snapshot and a local directory both work without a network round-trip.
 
 from pathlib import Path
 from unittest.mock import patch
@@ -61,7 +59,7 @@ def test_an_uncached_repo_still_downloads(component, loaded, tmp_path):
     with patch("mflux.models.common.resolution.path_resolution.HF_HUB_CACHE", str(tmp_path / "empty")):
         with patch("mflux.models.common.resolution.path_resolution.snapshot_download") as download:
             download.return_value = str(tmp_path / "fetched")
-            WeightLoader.load_single(component=component, repo_id="org/model", file_pattern="vae/*")
+            WeightLoader.load_single(component=component, repo_id="org/model", file_pattern="vae/*.safetensors")
 
     assert download.call_args[1]["repo_id"] == "org/model"
     assert loaded["root_path"] == tmp_path / "fetched"
@@ -69,10 +67,8 @@ def test_an_uncached_repo_still_downloads(component, loaded, tmp_path):
 
 @pytest.mark.fast
 def test_only_the_weight_pattern_decides_completeness(component, loaded, tmp_path):
-    # The repos behind two of the three components have no config.json at the root — the
-    # Lens VAE's FLUX.2-klein-4B keeps its under vae/ — so carrying the old allow_patterns
-    # over would have marked every cached copy of them incomplete, which is the one case
-    # this change exists to fix.
+    # A root config.json is deliberately absent: two of the three repos ship none, so
+    # requiring one would judge every cached copy of them incomplete.
     snapshot = tmp_path / "models--org--model" / "snapshots" / "abc123"
     (snapshot / "vae").mkdir(parents=True)
     (snapshot / "vae" / "diffusion_pytorch_model.safetensors").touch()
@@ -80,10 +76,27 @@ def test_only_the_weight_pattern_decides_completeness(component, loaded, tmp_pat
 
     with patch("mflux.models.common.resolution.path_resolution.HF_HUB_CACHE", str(tmp_path)):
         with patch("mflux.models.common.resolution.path_resolution.snapshot_download") as download:
-            WeightLoader.load_single(component=component, repo_id="org/model", file_pattern="vae/*")
+            WeightLoader.load_single(component=component, repo_id="org/model", file_pattern="vae/*.safetensors")
 
     download.assert_not_called()
     assert loaded["root_path"] == snapshot
+
+
+@pytest.mark.fast
+def test_a_half_downloaded_subdir_is_not_mistaken_for_a_complete_one(component, loaded, tmp_path):
+    # The pattern doubles as the completeness test, so it has to name the weights: "vae/*"
+    # is satisfied by a stray vae/config.json, and the repair download would never run.
+    snapshot = tmp_path / "models--org--model" / "snapshots" / "abc123"
+    (snapshot / "vae").mkdir(parents=True)
+    (snapshot / "vae" / "config.json").write_text("{}")
+
+    with patch("mflux.models.common.resolution.path_resolution.HF_HUB_CACHE", str(tmp_path)):
+        with patch("mflux.models.common.resolution.path_resolution.snapshot_download") as download:
+            download.return_value = str(tmp_path / "repaired")
+            WeightLoader.load_single(component=component, repo_id="org/model", file_pattern="vae/*.safetensors")
+
+    download.assert_called_once()
+    assert loaded["root_path"] == tmp_path / "repaired"
 
 
 @pytest.mark.fast
@@ -95,8 +108,8 @@ def test_the_patterns_reach_path_resolution(component, loaded, tmp_path, monkeyp
         return tmp_path
 
     monkeypatch.setattr(PathResolution, "resolve", record)
-    WeightLoader.load_single(component=component, repo_id="org/model", file_pattern="vae/*")
-    assert seen == {"path": "org/model", "patterns": ["vae/*"]}
+    WeightLoader.load_single(component=component, repo_id="org/model", file_pattern="vae/*.safetensors")
+    assert seen == {"path": "org/model", "patterns": ["vae/*.safetensors"]}
 
 
 @pytest.mark.fast


### PR DESCRIPTION
Closes #637, the parenthetical on the `mflux-format` checkbox in #577. @fxd0h's #603 fixed that checkbox's main clause; this is the note it carried: *"`load_single` bypasses `PathResolution` entirely — lens VAE — no offline fallback."*

### The gap

`WeightLoader.load_single` called `snapshot_download` directly. Every other weight load goes through `PathResolution.resolve`, which prefers a complete cached snapshot without a hub round-trip, takes a local directory as-is, and raises one uniform error on a miss. Three components got none of that — the FLUX controlnet ([flux_initializer.py:122](src/mflux/models/flux/flux_initializer.py#L122)), the Z-Image controlnet ([z_image_initializer.py:118](src/mflux/models/z_image/z_image_initializer.py#L118)) and the Lens VAE ([lens_image.py:67](src/mflux/models/lens/variants/txt2img/lens_image.py#L67)) — making them the only weights in the project that still want the network with everything already cached.

### The trap in the faithful translation

Passing the old patterns straight through (`[file_pattern, "config.json"]`) looks right and half-works. `_patterns_satisfied` requires **every** pattern to match a file really on disk, and against the actual repo listings:

| repo | root `config.json` |
| --- | --- |
| `InstantX/FLUX.1-dev-Controlnet-Canny` | present |
| `jasperai/Flux.1-dev-Controlnet-Upscaler` | present |
| `alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1` | **absent** |
| `black-forest-labs/FLUX.2-klein-4B` (Lens VAE) | **absent** — it is at `vae/config.json` |

The last two would have every cached copy judged incomplete and fall through to `snapshot_download` anyway — including the Lens VAE, the one case the note names. So only the weight pattern is passed.

Dropping `config.json` from the fetch is safe: nothing reads it out of this snapshot. `ZImageControlNetConfig.from_pretrained` issues its own `snapshot_download(allow_patterns=["config.json"])` and already falls back to `defaults_union_2_1()` when the repo has none — which is what happens for the alibaba repo today, since it has none.

This is #593's insight (*"download patterns are permissive filters, not a manifest"*) reached from the other side. I deliberately did **not** generalize it into `_is_snapshot_complete`'s no-subdirs branch: relaxing that globally would let a snapshot with every safetensors file but a missing `tokenizer.json` pass as complete, a real regression for the main `load` path. `load_single` loads exactly one component's weights, so it can be specific about what completeness means for it without changing that judgement for anyone else.

### Verification

7 new tests in `tests/resolution/test_load_single_path_resolution.py`, all offline: a complete cached snapshot is used with `snapshot_download` never called, a local directory stands in for the repo, an uncached repo still downloads, the patterns that reach `PathResolution` are exactly the weight pattern, a resolve-to-nothing names the component, and the direct `huggingface_hub` import stays gone.

The completeness test is the one that matters — it builds a `vae/`-only snapshot with no root `config.json` and asserts the cache is used, so it fails on the naive translation above.

`just lint`, `just typecheck` and the offline subset all clean (918 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of individual model weight files from cached snapshots, local directories, and repositories requiring downloads.
  * Added clearer component-specific errors when weight files cannot be resolved.
  * Ensured configured file patterns are consistently respected during weight loading.
  * Restricted VAE weight discovery to Safetensors files within the VAE directory.

* **Tests**
  * Added coverage for cached, local, and uncached weight-loading scenarios, including incomplete snapshots and resolution failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR routes single-component weight loading through the shared path resolver and completes the prior fix for weightless Lens VAE caches.
- Uses complete cached snapshots and local directories without unnecessary hub access.
- Restricts Lens VAE completeness and download matching to `vae/*.safetensors`.
- Adds offline tests for cache reuse, local resolution, downloads, patterns, and resolution failures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/common/weights/loading/weight_loader.py | Routes single-component loading through PathResolution while preserving the existing local weight-loading path. |
| src/mflux/models/lens/variants/txt2img/lens_image.py | Narrows Lens VAE resolution to its actual safetensors weights, completing the previously requested cache-completeness fix. |
| tests/resolution/test_load_single_path_resolution.py | Covers offline cache reuse, local paths, repair downloads, pattern propagation, and failed resolution. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[load_single] --> B[PathResolution.resolve]
    B --> C{Local or complete cached snapshot?}
    C -->|Yes| D[Use resolved root]
    C -->|No| E[Download matching weight files]
    E --> D
    D --> F[load_single_local]
    F --> G[Load component safetensors]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: name the safetensors in the lens VA..."](https://github.com/mflux-community/mflux/commit/0efe60044658cd557552776b19d15d7c641b25fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54169435)</sub>

<!-- /greptile_comment -->