### PR TITLE
fix: restore shared FLUX leaf parameterization

### DIFF
--- a/src/mflux/models/fibo/model/fibo_transformer/single_transformer_block.py
+++ b/src/mflux/models/fibo/model/fibo_transformer/single_transformer_block.py
@@ -17,7 +17,7 @@ class FiboSingleTransformerBlock(nn.Module):
         super().__init__()
         self.layer = layer
         self.mlp_hidden_dim = int(dim * mlp_ratio)
-        self.norm = AdaLayerNormZeroSingle()
+        self.norm = AdaLayerNormZeroSingle(dim=dim)
         self.proj_mlp = nn.Linear(dim, self.mlp_hidden_dim)
         self.act_mlp = nn.gelu_approx
         self.proj_out = nn.Linear(dim + self.mlp_hidden_dim, dim)

--- a/src/mflux/models/fibo/model/fibo_transformer/time_embed.py
+++ b/src/mflux/models/fibo/model/fibo_transformer/time_embed.py
@@ -9,7 +9,7 @@ class BriaFiboTimestepProjEmbeddings(nn.Module):
     def __init__(self, embedding_dim: int = 3072, time_theta: int = 10000):
         super().__init__()
         self.time_proj = BriaFiboTimesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0, time_theta=time_theta, scale=1.0)  # fmt: off
-        self.timestep_embedder = TimestepEmbedder()
+        self.timestep_embedder = TimestepEmbedder(dim=embedding_dim)
 
     def __call__(self, timestep: mx.array, dtype) -> mx.array:
         timesteps_proj = self.time_proj(timestep)

--- a/src/mflux/models/flux/model/flux_transformer/ada_layer_norm_zero_single.py
+++ b/src/mflux/models/flux/model/flux_transformer/ada_layer_norm_zero_single.py
@@ -3,14 +3,15 @@ from mlx import nn
 
 
 class AdaLayerNormZeroSingle(nn.Module):
-    def __init__(self):
+    def __init__(self, dim: int = 3072):
         super().__init__()
-        self.linear = nn.Linear(3072, 3 * 3072)
-        self.norm = nn.LayerNorm(dims=3072, eps=1e-6, affine=False)
+        self.dim = dim
+        self.linear = nn.Linear(dim, 3 * dim)
+        self.norm = nn.LayerNorm(dims=dim, eps=1e-6, affine=False)
 
     def __call__(self, hidden_states: mx.array, text_embeddings: mx.array) -> mx.array:
         text_embeddings = self.linear(nn.silu(text_embeddings))
-        chunk_size = 9216 // 3
+        chunk_size = self.dim
         shift_msa = text_embeddings[:, 0 * chunk_size : 1 * chunk_size]
         scale_msa = text_embeddings[:, 1 * chunk_size : 2 * chunk_size]
         gate_msa = text_embeddings[:, 2 * chunk_size : 3 * chunk_size]

--- a/src/mflux/models/flux/model/flux_transformer/timestep_embedder.py
+++ b/src/mflux/models/flux/model/flux_transformer/timestep_embedder.py
@@ -3,10 +3,10 @@ from mlx import nn
 
 
 class TimestepEmbedder(nn.Module):
-    def __init__(self):
+    def __init__(self, dim: int = 3072):
         super().__init__()
-        self.linear_1 = nn.Linear(256, 3072)
-        self.linear_2 = nn.Linear(3072, 3072)
+        self.linear_1 = nn.Linear(256, dim)
+        self.linear_2 = nn.Linear(dim, dim)
 
     def __call__(self, sample: mx.array) -> mx.array:
         sample = self.linear_1(sample)


### PR DESCRIPTION
fix ci broken test in ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transformer configuration so normalization and timestep embeddings use the model’s configured dimensions.
  * Enhanced compatibility across models with different embedding and block sizes.
  * Preserved existing conditioning and output behavior while reducing dimension-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores dimension parameterization for shared FLUX leaf modules while preserving the existing 3072 defaults.
- Passes the Fibo transformer width into its shared adaptive-normalization layer.
- Passes the Fibo embedding width into its shared timestep embedder.
- Replaces hardcoded 3072-dimensional layer construction and slicing with constructor dimensions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with shared-layer dimensions consistent across all current production callers.

The changed constructors preserve their 3072 defaults, Fibo now explicitly propagates matching dimensions, and no reachable shape, checkpoint-loading, serialization, or quantization failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/fibo/model/fibo_transformer/single_transformer_block.py | Propagates the block dimension into the shared adaptive-normalization module, keeping its tensors consistent with the surrounding Fibo block. |
| src/mflux/models/fibo/model/fibo_transformer/time_embed.py | Propagates the configured embedding width into the shared timestep embedder. |
| src/mflux/models/flux/model/flux_transformer/ada_layer_norm_zero_single.py | Parameterizes linear, normalization, and modulation-slice widths while retaining the existing 3072 default and parameter names. |
| src/mflux/models/flux/model/flux_transformer/timestep_embedder.py | Parameterizes both timestep projection layers while preserving the existing default behavior and checkpoint structure. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: restore shared FLUX leaf parameteri..."](https://github.com/mflux-community/mflux/commit/c6a39d3ee594d37268b7ac3ab1ffb98f2b5e1730) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54179541)</sub>

<!-- /greptile_comment -->