### PR TITLE
ci: gate PyPI publish behind a protected 'pypi' environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,25 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Deployment gate: requires reviewer approval and restricts publishable
+    # branches per the environment's protection rules (Settings > Environments > pypi).
+    # The PyPI trusted publisher is also pinned to this environment name.
+    environment: pypi
     permissions:
       contents: write
       pull-requests: read
       id-token: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          fetch-depth: 0 # Need full history for git operations
+      - name: Validate branch
+        # Defense in depth: the pypi environment's deployment branch policy is
+        # the primary gate; this fails fast with a clear message if dispatched
+        # from any ref other than main.
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "❌ Releases may only be published from main (got ${{ github.ref }})"
+            exit 1
+          fi
 
       - name: Validate confirmation
         run: |
@@ -28,6 +37,11 @@ jobs:
             echo "❌ Must type 'publish' to confirm release"
             exit 1
           fi
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0 # Need full history for git operations
 
       - name: Install uv and Python
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0


### PR DESCRIPTION
## Motivation

Follow-up to the 0.19.0 release security audit. Today, any collaborator with write access can dispatch the release workflow from **any branch** and publish to PyPI immediately — the `confirm: publish` input is an accident guard, not authorization, and PyPI trusted publishing pins only owner/repo/workflow filename unless an environment is also required.

## Changes

- Add `environment: pypi` to the release job. Once the environment is configured with required reviewers and a main-only deployment branch policy (repo settings, see below), every publish requires a second person's approval and can only run from `main`.
- Add a fail-fast **Validate branch** step (before checkout) that rejects dispatches from any ref other than `main` — defense in depth alongside the environment branch policy.

## Required admin setup (GitHub UI, one-time)

see: https://github.com/mflux-community/mflux/settings/environments/20076309752/edit

<img width="941" height="991" alt="image" src="https://github.com/user-attachments/assets/c8d6b64a-57c7-4f50-973f-131c78b45606" />

This PR is inert until the environment exists; an admin must:

1. ✅ **Settings → Environments → New environment** → name it `pypi`.
2. ✅ Check **Required reviewers** → add the admin group (filipstrand, anthonywu, fxd0h, ianscrivener). Check **Prevent self-review** so the dispatcher can't approve their own publish.
3. ✅**Deployment branches and tags** → *Selected branches and tags* → add branch rule `main`.
4. On **PyPI → project → Publishing → trusted publisher for mflux**: set the *Environment name* field to `pypi` so OIDC tokens are only honored from this gated environment. - I will need @filipstrand to execute this step as pypi owner.

Recommended companion (also UI): **Settings → Rules → Rulesets → New tag ruleset** targeting `v*` with *Restrict deletions* + *Block force pushes* (tag immutability).

## Behavior after merge + setup

Dispatching the workflow queues the run until one of the required reviewers (other than the dispatcher) approves the `pypi` deployment; runs from non-main refs are rejected by both the environment policy and the new guard step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release publishing safeguards by requiring releases to proceed through the protected publishing environment.
  * Added validation to ensure release dispatches originate from the designated primary branch.
  * Updated the release workflow to verify confirmation details before checking out source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a protected `pypi` environment to the release job and a main-branch validation step intended to provide defense in depth.
- Requires environment approval and external main-only deployment policy configuration before release steps run.
- Moves checkout after confirmation and branch validation.
- Introduces unsafe shell interpolation of the selected dispatch ref in the new branch guard.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until the branch guard stops evaluating the dispatch ref as shell source.

A crafted valid ref can reach direct shell interpolation whenever the externally managed environment policy is absent or permissive, executing commands before the non-main guard exits in a job with write and OIDC permissions.

**Files Needing Attention:** .github/workflows/release.yml

<details open><summary><h3>Security Review</h3></summary>

The new branch guard evaluates `github.ref` as shell source. During the documented pre-configuration window or after environment-policy drift, a crafted dispatch ref can execute commands with release-job write and OIDC permissions before being rejected.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds the protected release environment and branch guard, but the guard directly interpolates a dispatch-controlled ref into a privileged shell step. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[workflow_dispatch on selected ref] --> B{pypi environment policy blocks ref?}
    B -- Yes --> C[Job steps do not start]
    B -- No or not configured --> D[Validate branch shell step]
    D --> E[github.ref expanded into shell source]
    E --> F[Shell substitutions execute]
    F --> G[Branch comparison rejects non-main ref]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/release.yml:29-32
**Dispatch ref becomes shell code**

If the externally managed `pypi` environment is absent or permits a crafted dispatch ref, direct `${{ github.ref }}` expansion makes the shell evaluate substitutions in that ref before the comparison rejects it, allowing arbitrary commands to run with the release job's write and OIDC permissions. **How this was verified:** A valid shell-significant dispatch ref flows directly into shell source, whose substitutions execute before the guard's `exit 1`.

```suggestion
          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
            echo "❌ Releases may only be published from main (got $GITHUB_REF)"
            exit 1
          fi
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: gate PyPI publish behind a protected..."](https://github.com/mflux-community/mflux/commit/f22964ce280ade93dff3f1ac4c8d8bdcd1e74475) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54233408)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->