### PR TITLE
fix: shell completions track the installed commands and their real parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **Shell completions cover every installed command**: the generator's hand-maintained list had drifted six commands behind pyproject (`mflux-generate-boogu`, `mflux-generate-lens`, both `mflux-generate-ernie-image` commands, `mflux-generate-ideogram4`, `mflux-capabilities` never completed). Commands are now discovered from the installed console scripts and, where a CLI exposes `build_parser()`, completions are generated from the CLI's real parser instead of a hand-copied recipe of it. (#578, #651)
+
 ## [0.19.0] - 2026-08-18
 
 ### ⚠️ Behavior Changes

--- a/src/mflux/cli/capabilities.py
+++ b/src/mflux/cli/capabilities.py
@@ -209,12 +209,17 @@ def _to_markdown(capabilities: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Dump which options each mflux CLI actually honours.")
     parser.add_argument(
         "--command", type=str, default=None, help="Only dump this command (e.g. mflux-generate-z-image)."
     )
     parser.add_argument("--format", type=str, default="json", choices=["json", "yaml", "markdown"])
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
 
     capabilities = build_capabilities()

--- a/src/mflux/cli/completions/generator.py
+++ b/src/mflux/cli/completions/generator.py
@@ -10,14 +10,15 @@ from mflux.models.flux.variants.in_context.utils.in_context_loras import LORA_NA
 
 class CompletionGenerator:
     def __init__(self):
-        # Commands come from the installed console scripts, the same discovery
-        # mflux-capabilities uses, so a CLI wired into pyproject completes without this
-        # file changing. The hand-maintained list this replaces had drifted six commands
-        # behind (boogu, lens, both ernie-image, ideogram4, capabilities).
+        # Commands come from mflux's own console scripts, so a CLI wired into pyproject
+        # completes without this file changing. The hand-maintained list this replaces
+        # had drifted six commands behind (boogu, lens, both ernie-image, ideogram4,
+        # capabilities). Read off the mflux distribution rather than the global
+        # entry-point namespace so another installed package cannot inject a command.
         self._modules = {
             entry_point.name: entry_point.value.split(":")[0]
-            for entry_point in importlib.metadata.entry_points().select(group="console_scripts")
-            if entry_point.value.startswith("mflux.")
+            for entry_point in importlib.metadata.distribution("mflux").entry_points
+            if entry_point.group == "console_scripts"
         }
         self.commands = sorted(self._modules)
 
@@ -25,7 +26,10 @@ class CompletionGenerator:
         # A CLI that exposes build_parser() completes exactly what it parses; the
         # recipes below exist only for the commands that predate that convention and
         # build their parser inline in main().
-        module = importlib.import_module(self._modules[command])
+        try:
+            module = importlib.import_module(self._modules[command])
+        except Exception:  # noqa: BLE001 -- one broken CLI must not kill every other command's completions
+            module = None
         build_parser = getattr(module, "build_parser", None)
         if build_parser is not None:
             return build_parser()
@@ -73,10 +77,6 @@ class CompletionGenerator:
 
         elif command == "mflux-info":
             parser.add_info_arguments()
-
-        elif command == "mflux-capabilities":
-            parser.add_argument("--command", type=str, help="Only dump this command (e.g. mflux-generate-z-image).")
-            parser.add_argument("--format", type=str, choices=["json", "yaml", "markdown"], help="Output format")
 
         elif command == "mflux-completions":
             parser.add_argument("--print", action="store_true", help="Print completion script to stdout")

--- a/src/mflux/cli/completions/generator.py
+++ b/src/mflux/cli/completions/generator.py
@@ -1,4 +1,6 @@
 import argparse
+import importlib
+import importlib.metadata
 from pathlib import Path
 
 from mflux.cli.defaults import defaults as ui_defaults
@@ -8,198 +10,29 @@ from mflux.models.flux.variants.in_context.utils.in_context_loras import LORA_NA
 
 class CompletionGenerator:
     def __init__(self):
-        self.commands = [
-            "mflux-generate",
-            "mflux-generate-flux2",
-            "mflux-generate-flux2-edit",
-            "mflux-generate-controlnet",
-            "mflux-generate-kontext",
-            "mflux-generate-in-context",
-            "mflux-generate-in-context-edit",
-            "mflux-generate-in-context-catvton",
-            "mflux-generate-fill",
-            "mflux-generate-depth",
-            "mflux-generate-redux",
-            "mflux-generate-qwen",
-            "mflux-generate-qwen-edit",
-            "mflux-generate-fibo",
-            "mflux-generate-fibo-edit",
-            "mflux-generate-z-image",
-            "mflux-generate-z-image-turbo",
-            "mflux-generate-z-image-controlnet",
-            "mflux-generate-krea2",
-            "mflux-refine-fibo",
-            "mflux-inspire-fibo",
-            "mflux-concept",
-            "mflux-concept-from-image",
-            "mflux-save",
-            "mflux-save-depth",
-            "mflux-train",
-            "mflux-upscale-controlnet",
-            "mflux-upscale-seedvr2",
-            "mflux-lora-library",
-            "mflux-info",
-            "mflux-completions",
-        ]
+        # Commands come from the installed console scripts, the same discovery
+        # mflux-capabilities uses, so a CLI wired into pyproject completes without this
+        # file changing. The hand-maintained list this replaces had drifted six commands
+        # behind (boogu, lens, both ernie-image, ideogram4, capabilities).
+        self._modules = {
+            entry_point.name: entry_point.value.split(":")[0]
+            for entry_point in importlib.metadata.entry_points().select(group="console_scripts")
+            if entry_point.value.startswith("mflux.")
+        }
+        self.commands = sorted(self._modules)
 
     def create_parser_for_command(self, command: str) -> CommandLineParser:
+        # A CLI that exposes build_parser() completes exactly what it parses; the
+        # recipes below exist only for the commands that predate that convention and
+        # build their parser inline in main().
+        module = importlib.import_module(self._modules[command])
+        build_parser = getattr(module, "build_parser", None)
+        if build_parser is not None:
+            return build_parser()
+
         parser = CommandLineParser(prog=command, add_help=False)
 
-        if command == "mflux-generate":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
-            parser.add_image_to_image_arguments()
-            parser.add_image_outpaint_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-flux2":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-flux2-edit":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_paths_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-controlnet":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=True)
-            parser.add_lora_arguments()
-            parser.add_controlnet_arguments()
-            parser.add_image_generator_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-kontext":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
-            parser.add_image_to_image_arguments(required=True)
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-in-context":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_image_generator_arguments()
-            parser.add_image_to_image_arguments(required=True)
-            parser.add_in_context_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-in-context-edit":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=False, require_prompt=False)
-            parser.add_in_context_edit_arguments()
-            parser.add_in_context_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-in-context-catvton":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=False, require_prompt=False)
-            parser.add_catvton_arguments()
-            parser.add_in_context_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-fill":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments()
-            parser.add_fill_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-depth":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments()
-            parser.add_depth_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-redux":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments()
-            parser.add_redux_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-qwen":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=True)
-            parser.add_image_to_image_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-qwen-edit":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
-            parser.add_image_paths_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-fibo":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_image_generator_arguments(supports_metadata_config=True)
-            parser.add_image_to_image_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-fibo-edit":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.set_defaults(model="fibo-edit")
-            parser.add_image_generator_arguments(
-                supports_metadata_config=True,
-                require_prompt=False,
-                supports_dimension_scale_factor=True,
-            )
-            parser.add_argument(
-                "--image-path", type=Path, required=False, help="Local path to source image for editing."
-            )
-            parser.add_argument(
-                "--mask-path", type=Path, default=None, help="Optional mask image path for localized edits."
-            )
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-z-image-controlnet":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=False)
-            parser.add_union_controlnet_arguments(require_controls=True)
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-z-image-turbo":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=True)
-            parser.add_image_to_image_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-generate-krea2":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
-            parser.add_image_to_image_arguments(required=False)
-            parser.add_output_arguments()
-
-        elif command == "mflux-refine-fibo":
+        if command == "mflux-refine-fibo":
             parser.add_argument("--prompt-file", type=Path, required=True, help="Path to JSON prompt file to refine")
             parser.add_argument("--instructions", type=str, required=True, help="Text instructions for refinement")
             parser.add_argument("--output", type=Path, help="Output path for refined JSON prompt")
@@ -219,20 +52,6 @@ class CompletionGenerator:
             parser.add_argument("--max-tokens", type=int, help="Max tokens for VLM generation")
             parser.add_argument("--seed", type=int, help="Seed for VLM generation")
 
-        elif command == "mflux-concept":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=True)
-            parser.add_concept_attention_arguments()
-            parser.add_image_generator_arguments()
-            parser.add_output_arguments()
-
-        elif command == "mflux-concept-from-image":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=True)
-            parser.add_concept_from_image_arguments()
-            parser.add_image_generator_arguments()
-            parser.add_output_arguments()
-
         elif command == "mflux-save":
             parser.add_model_arguments(path_type="save", require_model_arg=True)
 
@@ -244,19 +63,6 @@ class CompletionGenerator:
             parser.add_model_arguments(require_model_arg=False)
             parser.add_training_arguments()
 
-        elif command == "mflux-upscale-controlnet":
-            parser.add_general_arguments()
-            parser.add_model_arguments(require_model_arg=False)
-            parser.add_lora_arguments()
-            parser.add_image_generator_arguments(supports_metadata_config=False, supports_dimension_scale_factor=True)
-            parser.add_controlnet_arguments(require_image=True)
-            parser.add_output_arguments()
-
-        elif command == "mflux-upscale-seedvr2":
-            parser.add_general_arguments()
-            parser.add_seedvr2_upscale_arguments()
-            parser.add_output_arguments()
-
         elif command == "mflux-lora-library":
             # Special case: has subcommands
             subparsers = parser.add_subparsers(dest="command")
@@ -267,6 +73,10 @@ class CompletionGenerator:
 
         elif command == "mflux-info":
             parser.add_info_arguments()
+
+        elif command == "mflux-capabilities":
+            parser.add_argument("--command", type=str, help="Only dump this command (e.g. mflux-generate-z-image).")
+            parser.add_argument("--format", type=str, choices=["json", "yaml", "markdown"], help="Output format")
 
         elif command == "mflux-completions":
             parser.add_argument("--print", action="store_true", help="Print completion script to stdout")

--- a/tests/cli/test_completion_generator.py
+++ b/tests/cli/test_completion_generator.py
@@ -74,8 +74,8 @@ def test_completion_generator_tracks_installed_console_scripts():
 
     installed = {
         entry_point.name
-        for entry_point in importlib.metadata.entry_points().select(group="console_scripts")
-        if entry_point.value.startswith("mflux.")
+        for entry_point in importlib.metadata.distribution("mflux").entry_points
+        if entry_point.group == "console_scripts"
     }
     assert set(generator.commands) == installed
     for command in (

--- a/tests/cli/test_completion_generator.py
+++ b/tests/cli/test_completion_generator.py
@@ -61,3 +61,43 @@ def test_completion_generator_includes_atomic_lora_and_image_flags():
     assert "'--image''[" in script
     assert "'--lora-paths''[" in script
     assert "'--image-path''[" in script
+
+
+@pytest.mark.fast
+def test_completion_generator_tracks_installed_console_scripts():
+    # The command list is read off the installed entry points, so it can no longer
+    # drift behind pyproject the way the hand list did (it was six commands behind:
+    # boogu, lens, both ernie-image, ideogram4 and capabilities).
+    import importlib.metadata
+
+    generator = CompletionGenerator()
+
+    installed = {
+        entry_point.name
+        for entry_point in importlib.metadata.entry_points().select(group="console_scripts")
+        if entry_point.value.startswith("mflux.")
+    }
+    assert set(generator.commands) == installed
+    for command in (
+        "mflux-generate-boogu",
+        "mflux-generate-lens",
+        "mflux-generate-ernie-image",
+        "mflux-generate-ernie-image-turbo",
+        "mflux-generate-ideogram4",
+        "mflux-capabilities",
+    ):
+        assert command in generator.commands
+
+
+@pytest.mark.fast
+def test_completion_generator_prefers_the_cli_own_parser():
+    # A build_parser command completes what its CLI actually parses; drift between the
+    # completion recipe and the real parser is impossible for these. Lens never had a
+    # recipe in the old hand-maintained chain, so its flags only complete via this path.
+    generator = CompletionGenerator()
+
+    script = generator.generate_command_function(
+        "mflux-generate-lens", generator.create_parser_for_command("mflux-generate-lens")
+    )
+    assert "_mflux_generate_lens()" in script
+    assert "--prompt" in script


### PR DESCRIPTION
## What

The completions generator kept a hand list of 31 commands and a 200-line elif chain of parser recipes, and both had drifted: boogu, lens, both ernie-image commands, ideogram4 and capabilities were missing entirely, and every recipe was a second copy of some CLI's parser that nothing kept honest. Commands are now read off the installed console scripts (the same discovery mflux-capabilities uses), and any CLI that exposes `build_parser()` completes exactly what it parses. The recipe chain survives only for the nine commands that still build their parser inline in `main()` (save, train, info, the fibo VLM pair, and friends), plus a new recipe for mflux-capabilities. The #613 crash fix is what made building every parser at generation time safe. Net -190 lines.

Part of #578.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default
- [x] `ruff check` and `ruff format` are clean
- [x] `CHANGELOG.md`: entry under `Unreleased` (follow-up commit with this PR's number)
- [x] Docs updated where behavior changed (none: mflux-completions usage is unchanged)
- [ ] New model: n/a
- [x] New/changed CLI: no option changes

## Verification

On an M5: full CI selector, 1438 passed / 62 deselected; `ruff check` and `ty check` clean. Ran `mflux-completions --print`: the header lists all 37 installed commands (was 31) and every command function generates. A new test pins the command set to the installed entry points, so the list can't drift behind pyproject again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell completion by automatically discovering all installed commands.
  * Updated completions to accurately reflect each command’s available options.
  * Added completion support for capabilities and Lens commands.
  * Improved consistency as new commands and options are added.
* **Documentation**
  * Documented the shell-completion improvements in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the hand-maintained completion command list with entry points owned by the installed `mflux` distribution and reuses each CLI’s parser builder where available.
- Adds a reusable parser builder for `mflux-capabilities`.
- Preserves parser recipes for commands that still construct parsers inline.
- Adds tests covering installed command discovery and Lens parser reuse.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported cross-package entry-point injection is removed by reading console scripts from the installed `mflux` distribution itself.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/cli/completions/generator.py | Discovers only the `mflux` distribution’s console scripts, resolving the previously reported global entry-point boundary issue. |
| src/mflux/cli/capabilities.py | Extracts parser construction into `build_parser()` so completion generation can reuse the real CLI parser. |
| tests/cli/test_completion_generator.py | Verifies that completion commands match installed entry points and that CLI-owned parsers supply completion options. |
| CHANGELOG.md | Documents the expanded and parser-aligned shell completion behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into completions-reg..."](https://github.com/mflux-community/mflux/commit/bfcbc3a823d6a45afc3cfd867cbc906809094938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54348712)</sub>

<!-- /greptile_comment -->