### PR TITLE
fix: mflux-capabilities publishes wire types, not converter function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **`mflux-capabilities` publishes wire types, not Python converter names**: options validated by a named converter leaked the function name as their type (`--vae-tile-size` claimed type `vae_tile_size`, `--mlx-cache-limit-gb` claimed `positive_float`, every Path option claimed `PosixPath`). Named converters now map to what they yield: `int`, `float`, `path`, and `int-or-scale` for values that accept a pixel count, a `2x` factor or `auto`. The dump's type field is pinned to that closed vocabulary by a test. (#578, #652)
+
 ## [0.19.0] - 2026-08-18
 
 ### ⚠️ Behavior Changes

--- a/src/mflux/cli/capabilities.py
+++ b/src/mflux/cli/capabilities.py
@@ -24,7 +24,10 @@ import argparse
 import importlib.metadata
 import json
 import sys
+from pathlib import Path
 from typing import Any
+
+from mflux.cli.parser import parsers as _parsers
 
 SCHEMA_VERSION = 1
 
@@ -47,6 +50,19 @@ def discover_commands() -> list[tuple[str, str]]:
     return sorted(set(found))
 
 
+# Named converters publish the wire type of what they yield, not their Python function
+# name: `--vae-tile-size` takes an int whether or not a validator named vae_tile_size
+# clamps it, and a path is a path however pathlib spells it. Keyed by identity so a
+# renamed converter cannot silently fall back to leaking its new name.
+_CONVERTER_WIRE_TYPES = {
+    _parsers.positive_float: "float",
+    _parsers.finite_float: "float",
+    _parsers.vae_tile_size: "int",
+    _parsers.int_or_special_value: "int-or-scale",
+    Path: "path",
+}
+
+
 def _option_type_name(action: argparse.Action) -> str:
     if isinstance(action, (argparse._StoreTrueAction, argparse._StoreFalseAction)):
         return "bool"
@@ -54,6 +70,11 @@ def _option_type_name(action: argparse.Action) -> str:
         return "bool"
     if action.type is None:
         return "str"
+    try:
+        if action.type in _CONVERTER_WIRE_TYPES:
+            return _CONVERTER_WIRE_TYPES[action.type]
+    except TypeError:  # an unhashable custom converter object; fall through to its name
+        pass
     name = getattr(action.type, "__name__", str(action.type))
     if name == "<lambda>":
         # An anonymous converter has no publishable name; the default's type is the

--- a/tests/cli/test_capabilities.py
+++ b/tests/cli/test_capabilities.py
@@ -179,6 +179,17 @@ def test_capabilities_types_stay_in_the_wire_vocabulary(caps):
         for option in command["options"]:
             assert option["type"] in allowed, f"{command['command']} {option['flag']} publishes {option['type']!r}"
 
+    # And each converter maps to its own wire type, not merely to something in the
+    # vocabulary: one representative option per converter.
+    def type_of(command_name: str, flag: str) -> str:
+        command = next(c for c in caps["commands"] if c["command"] == command_name)
+        return next(o for o in command["options"] if o["flag"] == flag)["type"]
+
+    assert type_of("mflux-generate", "--vae-tile-size") == "int"
+    assert type_of("mflux-generate", "--mlx-cache-limit-gb") == "float"
+    assert type_of("mflux-upscale-seedvr2", "--resolution") == "int-or-scale"
+    assert type_of("mflux-upscale-seedvr2", "--image-path") == "path"
+
 
 @pytest.mark.fast
 def test_jsonable_preserves_mappings():

--- a/tests/cli/test_capabilities.py
+++ b/tests/cli/test_capabilities.py
@@ -169,6 +169,18 @@ def test_capabilities_lambda_converter_publishes_default_type():
 
 
 @pytest.mark.fast
+def test_capabilities_types_stay_in_the_wire_vocabulary(caps):
+    # Named converters used to leak their Python function names as types
+    # (vae_tile_size, positive_float, int_or_special_value, PosixPath). The dump's type
+    # field is a closed vocabulary; a new converter must be added to
+    # _CONVERTER_WIRE_TYPES, and this names the leak when it isn't.
+    allowed = {"str", "int", "float", "bool", "path", "int-or-scale"}
+    for command in caps["commands"]:
+        for option in command["options"]:
+            assert option["type"] in allowed, f"{command['command']} {option['flag']} publishes {option['type']!r}"
+
+
+@pytest.mark.fast
 def test_jsonable_preserves_mappings():
     # A dict default must stay a JSON object, not become a Python repr string.
     from pathlib import Path


### PR DESCRIPTION
## What

The last open converter leak from the #578 audit: `_option_type_name` handled anonymous lambdas but let named converters publish their Python function names as option types, so the dump said `--vae-tile-size` takes a `vae_tile_size`, `--mlx-cache-limit-gb` a `positive_float`, `--resolution` an `int_or_special_value`, and every Path option a `PosixPath`. There's now an explicit converter-to-wire-type map, keyed by function identity so a renamed converter can't silently fall back to leaking its new name: the validators map to what they yield (`int`, `float`), `Path` maps to `path`, and `int_or_special_value` maps to `int-or-scale` since it genuinely accepts a pixel count, a `2x` scale factor or `auto`. A test pins the whole dump to the closed vocabulary {str, int, float, bool, path, int-or-scale}, so the next named converter fails CI by name until it's mapped.

Part of #578.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default
- [x] `ruff check` and `ruff format` are clean
- [x] `CHANGELOG.md`: entry under `Unreleased` (follow-up commit with this PR's number)
- [x] Docs updated where behavior changed (the dump's own docstring already promises introspected truth; no README examples show the leaked names)
- [ ] New model: n/a
- [x] New/changed CLI: no option changes; the capabilities dump is the change

## Verification

On an M5: full CI selector green (the one red I hit is tests/pid_decoder/test_gemma2_shapes.py::test_gemma2_model_is_causal, which also fails ~1 in 3 full-suite runs on pristine origin/main — separate flake, fix incoming in its own PR); `ruff check` and `ty check` clean. Built the real dump: 837 options across 28 commands now publish only the six vocabulary types, where before `vae_tile_size`, `positive_float`, `int_or_special_value` and `PosixPath` appeared 100+ times combined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected capability reporting for option types, including integers, floating-point values, paths, and integer-or-scale options.
  * Ensured reported types use a consistent, supported vocabulary.
* **Tests**
  * Added coverage to verify capability option types remain within the supported wire-format values.
* **Documentation**
  * Documented the fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes capability output to publish stable wire-format types instead of Python converter names.
- Adds explicit mappings for validated floats, validated integers, paths, and integer-or-scale values.
- Adds full-dump coverage enforcing the supported type vocabulary and representative converter mappings.
- Documents the correction in the unreleased changelog.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/cli/capabilities.py | Maps every currently used named parser converter to its intended wire type without introducing an import cycle or unsupported dependency. |
| tests/cli/test_capabilities.py | Pins the complete capabilities dump to the closed type vocabulary and verifies representative mappings. |
| CHANGELOG.md | Accurately documents the corrected capability type labels. |

</details>

<sub>Reviews (2): Last reviewed commit: ["review: pin each converter&#39;s exact wire ..."](https://github.com/mflux-community/mflux/commit/ca8df67dbc828e99fd60208bfab7535292565ce6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54351653)</sub>

<!-- /greptile_comment -->