### PR TITLE
tests: fix the flaky gemma2 causality test (out-of-vocab token)

### DIFF
--- a/tests/pid_decoder/test_gemma2_shapes.py
+++ b/tests/pid_decoder/test_gemma2_shapes.py
@@ -61,8 +61,13 @@ def test_gemma2_model_is_causal():
         head_dim=8,
     )
     model = Gemma2Model(config)
+    # Both sequences must stay inside vocab_size (32): token 99 was an out-of-bounds
+    # embedding lookup, which MLX does not bounds-check on GPU, so position 3's row came
+    # from whatever memory the gather landed on and the "outputs must differ" half of
+    # this test failed in roughly one full-suite run out of three, while passing in
+    # isolation, where the heap it read was fresh.
     input_ids_a = mx.array([[1, 2, 3, 4]])
-    input_ids_b = mx.array([[1, 2, 3, 99]])
+    input_ids_b = mx.array([[1, 2, 3, 31]])
 
     out_a = model(input_ids_a)
     out_b = model(input_ids_b)


### PR DESCRIPTION
## What

`test_gemma2_model_is_causal` failed roughly one full-suite run in three on my machine while always passing in isolation. Its second sequence ends in token 99 against `vocab_size=32`: an out-of-bounds embedding lookup, which MLX doesn't bounds-check, so position 3's embedding row is whatever memory the gather lands on. In a fresh process that memory read back as zeros; mid-suite it depends on what earlier tests left on the heap, and occasionally it satisfies `allclose` against token 4's row, failing the "outputs must differ" half. The token is now 31, the last valid row.

Hit while validating #652, but it reproduces on pristine main and predates anything of mine.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default
- [x] `ruff check` and `ruff format` are clean
- [x] `CHANGELOG.md`: skipped, test-only change (precedent #599, #633)
- [x] Docs: n/a
- [ ] New model: n/a
- [ ] New/changed CLI: n/a

## Verification

On an M5, `uv run pytest -m "not slow and not high_memory_requirement"` on pristine origin/main failed 3 times in 14 runs, always this test. With the one-token change: 10 consecutive full-suite runs green. Probing the mechanism directly: `nn.Embedding(32, 16)` indexed at 99 returns neither row 31 nor an error, it returned an all-zeros row from out-of-bounds memory.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces an out-of-vocabulary token in the Gemma2 causality test with the last valid vocabulary token, eliminating undefined embedding lookup behavior while preserving the test’s causal assertions.

- Changes the second sequence’s final token from 99 to 31 for a vocabulary size of 32.
- Documents why the previous out-of-bounds lookup caused full-suite flakiness.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the test-only change removing an out-of-bounds embedding lookup without weakening the causality check.

Token 31 is a valid, ordinary embedding index for the configured vocabulary and remains distinct from token 4, so both existing causality assertions retain their intended behavior.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/pid_decoder/test_gemma2_shapes.py | The updated token remains distinct but is now in bounds, preserving the causality check while removing the flaky MLX embedding lookup. |

</details>

<sub>Reviews (1): Last reviewed commit: ["tests: keep the gemma2 causality probe i..."](https://github.com/mflux-community/mflux/commit/f7f189dec158b2309ad3ce1bfaa5e93b58ea90c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54352428)</sub>

<!-- /greptile_comment -->