### PR TITLE
refactor: the Lens DiT loads through the shared WeightDefinition seam

### DIFF
--- a/src/mflux/models/lens/variants/txt2img/lens_image.py
+++ b/src/mflux/models/lens/variants/txt2img/lens_image.py
@@ -11,8 +11,6 @@ import math
 import time
 
 import mlx.core as mx
-import mlx.nn as nn
-from mlx.utils import tree_unflatten
 
 from mflux.callbacks.callback_registry import CallbackRegistry
 from mflux.models.common.config import ModelConfig
@@ -27,10 +25,10 @@ from mflux.models.lens.model.text_encoder.lens_gpt_oss_encoder import (
     LensGptOssEncoder,
 )
 from mflux.models.lens.model.transformer.lens_transformer import LensTransformer
+from mflux.models.lens.weights.lens_weight_definition import TURBO_WEIGHTS_PATTERN, LensWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.image_util import ImageUtil
 
-TURBO_WEIGHTS_PATTERN = "diffusion_models/lens_turbo_bf16.safetensors"
 VAE_REPO = "black-forest-labs/FLUX.2-klein-4B"
 
 
@@ -52,15 +50,23 @@ class LensImage:
         )
         self.text_encoder = LensGptOssEncoder(str(encoder_root))
 
-        dit_root = PathResolution.resolve(
-            path=model_path or self.model_config.model_name,
-            patterns=[TURBO_WEIGHTS_PATTERN],
-        )
+        # The DiT loads through the shared seam rather than a raw mx.load: same hub and
+        # local-path resolution as every other model, and a checkpoint that mflux saved
+        # already quantized reloads through the applier's stored-quantization path.
+        transformer_component = LensWeightDefinition.get_components()[0]
         self.transformer = LensTransformer()
-        weights = mx.load(str(dit_root / TURBO_WEIGHTS_PATTERN))
-        self.transformer.update(tree_unflatten([(k, v.astype(mx.bfloat16)) for k, v in weights.items()]))
-        if quantize is not None:
-            nn.quantize(self.transformer, bits=quantize, class_predicate=lambda p, m: hasattr(m, "to_quantized"))
+        transformer_weights = WeightLoader.load_single(
+            component=transformer_component,
+            repo_id=model_path or self.model_config.model_name,
+            file_pattern=TURBO_WEIGHTS_PATTERN,
+        )
+        WeightApplier.apply_and_quantize_single(
+            transformer_weights,
+            self.transformer,
+            transformer_component,
+            quantize,
+            quantization_predicate=LensWeightDefinition.quantization_predicate,
+        )
         mx.eval(self.transformer.parameters())
 
         vae_component = [c for c in Flux2KleinWeightDefinition.get_components() if c.name == "vae"][0]

--- a/src/mflux/models/lens/weights/lens_weight_definition.py
+++ b/src/mflux/models/lens/weights/lens_weight_definition.py
@@ -1,0 +1,40 @@
+from typing import List
+
+from mflux.models.common.config.model_config import ModelConfig
+from mflux.models.common.weights.loading.weight_definition import ComponentDefinition
+
+# The single-file native checkpoint inside the Comfy-Org mirror (the Microsoft
+# originals were withdrawn). Its tensor names already match LensTransformer's module
+# paths, so the component loads in passthrough mode, the same arrangement as the
+# ERNIE and Krea 2 native checkpoints.
+TURBO_WEIGHTS_PATTERN = "diffusion_models/lens_turbo_bf16.safetensors"
+
+
+class LensWeightDefinition:
+    """Lens Turbo assembles from three repositories, and this definition covers the one
+    the model config names: the DiT repo. The FLUX.2 VAE loads through
+    Flux2KleinWeightDefinition's vae component from the klein repo, and the GPT-OSS 20B
+    text encoder is a pre-quantized mlx-format checkpoint whose config carries its own
+    quantization recipe (mxfp4 experts + q8 elsewhere), so it self-describes through
+    LensGptOssEncoder and never passes through WeightApplier."""
+
+    @staticmethod
+    def get_components() -> List[ComponentDefinition]:
+        return [
+            ComponentDefinition(
+                name="transformer",
+                hf_subdir="diffusion_models",
+                loading_mode="mlx_native",
+                weight_files=["lens_turbo_bf16.safetensors"],
+                precision=ModelConfig.precision,
+                mapping_getter=None,  # direct load; checkpoint keys are the module paths
+            ),
+        ]
+
+    @staticmethod
+    def get_download_patterns() -> List[str]:
+        return [TURBO_WEIGHTS_PATTERN]
+
+    @staticmethod
+    def quantization_predicate(path: str, module) -> bool:
+        return hasattr(module, "to_quantized")


### PR DESCRIPTION
## What

The last piece of #579, and a #578 checkbox: LensImage loaded its DiT with a raw `mx.load` + `tree_unflatten` + inline `nn.quantize`, the only model component in the tree that bypassed the loader seam entirely. There's now a `LensWeightDefinition` whose transformer component loads in passthrough mode (the Comfy-Org checkpoint's tensor names are already the module paths, the same arrangement as the ERNIE and Krea 2 native checkpoints), and LensImage routes it through `WeightLoader.load_single` + `WeightApplier.apply_and_quantize_single`. That buys the standard behaviors for free: mflux-format detection first, the #603 missing-shard error naming files instead of a bare KeyError, and the applier's stored-quantization reload path, though that last one stays unreachable until Lens grows save support.

Deliberately out of scope, per the definition's docstring: the FLUX.2 VAE keeps loading through `Flux2KleinWeightDefinition`'s vae component from the klein repo, and the GPT-OSS 20B encoder stays outside `WeightApplier`, it's a pre-quantized mlx-format checkpoint whose config carries its own mxfp4+q8 recipe and self-describes through `LensGptOssEncoder`.

Part of #578.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default (existing lens tests cover the seam; the real proof needs the 20B weights, below)
- [x] `ruff check` and `ruff format` are clean
- [x] `CHANGELOG.md`: skipped, no user-visible behavior change (loader internals; happy to add one if preferred)
- [x] Docs: n/a, no interface change
- [ ] New model: n/a
- [ ] New/changed CLI: n/a

## Verification

On an M5 with the real weights (GPT-OSS 20B MXFP4-Q8 encoder + 3.8B DiT):

- `mflux-generate-lens --steps 4 --seed 11` at 512px on this branch vs main: pixel-identical, numpy maxdiff 0, 12.49 GB peak both.
- `-q 8` with `--model <local snapshot dir>`: correct image at 12.74 GB peak, exercising the quantize path and local-path resolution through the new component.
- Full CI selector: 1436 passed / 62 deselected; `ruff check` and `ty check` clean.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves Lens Turbo’s DiT checkpoint loading onto the shared weight-definition, loader, and applier infrastructure while preserving its bfloat16 and on-the-fly quantization behavior.
- Adds a passthrough `LensWeightDefinition` for the native transformer checkpoint.
- Replaces direct `mx.load`, `tree_unflatten`, and inline quantization with `WeightLoader.load_single` and `WeightApplier.apply_and_quantize_single`.
- Leaves the separately sourced VAE and self-describing GPT-OSS encoder loading paths unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified in checkpoint resolution, dtype conversion, or quantization behavior.

The shared loader resolves the same checkpoint, preserves the previous bfloat16 conversion, and the reachable quantization path retains the prior update ordering, predicate, bit selection, and group-size behavior.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/lens/variants/txt2img/lens_image.py | Routes Lens transformer loading and quantization through the shared loader/applier seam while retaining explicit parameter evaluation. |
| src/mflux/models/lens/weights/lens_weight_definition.py | Defines the native transformer checkpoint location, bfloat16 precision, passthrough mapping, and quantizable-module predicate. |
| src/mflux/models/lens/weights/__init__.py | Introduces the Lens weights package without runtime behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[LensImage initialization] --> B[LensWeightDefinition transformer component]
    B --> C[WeightLoader.load_single]
    C --> D{MFlux-format metadata?}
    D -->|Yes| E[Load stored-format weights and quantization metadata]
    D -->|No| F[Load native Lens safetensors]
    F --> G[Convert tensors to bfloat16]
    E --> H[WeightApplier.apply_and_quantize_single]
    G --> H
    H --> I{Quantization source}
    I -->|Stored| J[Configure quantized layers then apply weights]
    I -->|Requested| K[Apply weights then quantize eligible layers]
    I -->|None| L[Apply weights directly]
    J --> M[mx.eval transformer parameters]
    K --> M
    L --> M
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: lens DiT loads through WeightD..."](https://github.com/mflux-community/mflux/commit/bfe728222bf4b0edcada522e36c1d460c1144831) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54354976)</sub>

<!-- /greptile_comment -->