### PR TITLE
docs: add Lens and Boogu Image to the models table with per-model READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,11 @@ MFLUX supports the following model families. They have different strengths and w
 | --- | --- | --- | --- | --- | --- |
 |[Z-Image](src/mflux/models/z_image/README.md) | Nov 2025 | 6B | Distilled & Base | Yes | Fast, small, very good quality and realism. |
 |[Krea 2](src/mflux/models/krea2/README.md) | Jun 2026 | 12B | Turbo (distilled) | No | Very good quality with a wide range of styles; good for creative exploration. |
-|[FLUX.2](src/mflux/models/flux2/README.md) | Jan 2026 | 4B & 9B | Distilled & Base | Yes | Fastest + smallest with very good qaility and edit capabilities. |
+|[FLUX.2](src/mflux/models/flux2/README.md) | Jan 2026 | 4B & 9B | Distilled & Base | Yes | Fastest + smallest with very good quality and edit capabilities. |
 |[Ideogram 4](src/mflux/models/ideogram4/README.md) | Jun 2026 | 9B | Base | No | JSON-caption-native, typography-focused text-to-image generation. |
 |[ERNIE-Image](src/mflux/models/ernie_image/README.md) | Apr 2026 | 8B | Distilled & Base | No | Single-stream DiT from Baidu. Vivid, high-contrast output. |
+|[Lens](src/mflux/models/lens/README.md) | May 2026 | 3.8B (+20B TE) | Turbo (distilled) | No | Dual-stream MMDiT from Microsoft with a GPT-OSS text encoder. Strong prompt adherence in 4 steps. |
+|[Boogu Image](src/mflux/models/boogu/README.md) | Jun 2026 | 10B | Turbo (distilled) | No | DMD-distilled 4-step model with a photographic look and bilingual (EN/ZH) text rendering. |
 |[FIBO](src/mflux/models/fibo/README.md) | Oct 2025+ | 8B | Distilled & Base | No | Very good JSON-based prompt understanding. Has edit capabilities. |
 |[SeedVR2](src/mflux/models/seedvr2/README.md) | Jun 2025 | 3B & 7B | — | No | Best upscaling model. |
 |[Qwen Image](src/mflux/models/qwen/README.md) | Aug 2025+ | 20B | Base | No | Large model (slower); strong prompt understanding and world knowledge. Has edit capabilities |
@@ -183,6 +185,8 @@ MFLUX would not be possible without the great work of:
 - Ideogram for the [Ideogram 4 project](https://huggingface.co/ideogram-ai/ideogram-4-fp8)
 - Krea.ai for the [Krea 2 project](https://www.krea.ai/blog/krea-2-technical-report)
 - Qwen Team for the [Qwen Image project](https://qwen.ai/blog?id=a6f483777144685d33cd3d2af95136fcbeb57652&from=research.research-list)
+- Microsoft for the Lens (Turbo) model, and Comfy-Org for the [weights repackage](https://huggingface.co/Comfy-Org/Lens)
+- The Boogu team for the [Boogu Image project](https://huggingface.co/Boogu/Boogu-Image-0.1-Turbo)
 - ByteDance, @numz and @adrientoupet for the [SeedVR2 project](https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler)
 - Hugging Face for the [Diffusers library implementations](https://github.com/huggingface/diffusers) 
 - Depth Pro authors for the [Depth Pro model](https://github.com/apple/ml-depth-pro?tab=readme-ov-file#citation)

--- a/src/mflux/models/boogu/README.md
+++ b/src/mflux/models/boogu/README.md
@@ -1,0 +1,48 @@
+# Boogu Image
+
+This directory contains MFLUX's MLX implementation of **Boogu-Image-0.1-Turbo**
+([`Boogu/Boogu-Image-0.1-Turbo`](https://huggingface.co/Boogu/Boogu-Image-0.1-Turbo)).
+
+Boogu Image Turbo is a 10B text-to-image model from the Boogu team (Apache 2.0),
+DMD-distilled down to 4 steps. It leans photographic, with natural lighting and solid
+bilingual (English/Chinese) text rendering. Guidance is distilled in: `--guidance` and
+`--negative-prompt` are accepted but ignored (the CLI warns when you pass them).
+
+## Example
+
+```sh
+mflux-generate-boogu \
+  --prompt "A street food vendor at night under paper lanterns, steam rising, neon reflections on wet pavement" \
+  --width 768 \
+  --height 768 \
+  --seed 42 \
+  --steps 4 \
+  -q 8
+```
+
+4 steps is enough up to ~768px; at 1024x1024 use `--steps 8`, where 4 steps
+under-resolves fine detail. Quantization (`-q 3|4|5|6|8`) is supported. LoRA flags are
+not available for this model.
+
+<details>
+<summary>Python API</summary>
+
+```python
+from mflux.models.boogu import BooguImage
+from mflux.models.common.config import ModelConfig
+
+model = BooguImage(
+    model_config=ModelConfig.boogu_image_turbo(),
+    quantize=8,
+)
+image = model.generate_image(
+    seed=42,
+    prompt="A street food vendor at night under paper lanterns, steam rising, neon reflections on wet pavement",
+    width=768,
+    height=768,
+    num_inference_steps=4,
+)
+image.save(path="boogu.png")
+```
+
+</details>

--- a/src/mflux/models/lens/README.md
+++ b/src/mflux/models/lens/README.md
@@ -5,8 +5,13 @@ This directory contains MFLUX's MLX implementation of **Microsoft Lens (Turbo)**
 Lens Turbo pairs a 3.8B dual-stream MMDiT (48 blocks) with a GPT-OSS 20B multi-layer text
 encoder and reuses the FLUX.2 VAE already in-tree. It is a 4-step distillation with CFG
 internalized, so `--guidance`, `--negative-prompt` and `--scheduler` are accepted but
-ignored (the CLI warns when you pass them). Weights download from
-[`Comfy-Org/Lens`](https://huggingface.co/Comfy-Org/Lens) on first run.
+ignored (the CLI warns when you pass them).
+
+Weights assemble from three repositories on first run: the DiT from
+[`Comfy-Org/Lens`](https://huggingface.co/Comfy-Org/Lens) (the Microsoft originals were
+withdrawn), the GPT-OSS 20B encoder from
+[`mlx-community/gpt-oss-20b-MXFP4-Q8`](https://huggingface.co/mlx-community/gpt-oss-20b-MXFP4-Q8),
+and the FLUX.2 VAE from the klein repository already used by the flux2 family.
 
 ## Example
 
@@ -20,8 +25,9 @@ mflux-generate-lens \
   -q 8
 ```
 
-Quantization (`-q 3|4|5|6|8`) is supported and recommended: the GPT-OSS encoder is the
-bulk of the memory footprint. LoRA flags are not available for this model.
+Quantization (`-q 3|4|5|6|8`) applies to the DiT; the GPT-OSS encoder ships pre-quantized
+(MXFP4 experts, q8 elsewhere) and is unaffected by the flag. LoRA flags are not available
+for this model.
 
 <details>
 <summary>Python API</summary>

--- a/src/mflux/models/lens/README.md
+++ b/src/mflux/models/lens/README.md
@@ -1,0 +1,47 @@
+# Lens
+
+This directory contains MFLUX's MLX implementation of **Microsoft Lens (Turbo)**.
+
+Lens Turbo pairs a 3.8B dual-stream MMDiT (48 blocks) with a GPT-OSS 20B multi-layer text
+encoder and reuses the FLUX.2 VAE already in-tree. It is a 4-step distillation with CFG
+internalized, so `--guidance`, `--negative-prompt` and `--scheduler` are accepted but
+ignored (the CLI warns when you pass them). Weights download from
+[`Comfy-Org/Lens`](https://huggingface.co/Comfy-Org/Lens) on first run.
+
+## Example
+
+```sh
+mflux-generate-lens \
+  --prompt "A cozy bookshop cafe at dusk, warm light through the window, a cat sleeping on a stack of books" \
+  --width 512 \
+  --height 512 \
+  --seed 7 \
+  --steps 4 \
+  -q 8
+```
+
+Quantization (`-q 3|4|5|6|8`) is supported and recommended: the GPT-OSS encoder is the
+bulk of the memory footprint. LoRA flags are not available for this model.
+
+<details>
+<summary>Python API</summary>
+
+```python
+from mflux.models.common.config import ModelConfig
+from mflux.models.lens.variants.txt2img.lens_image import LensImage
+
+model = LensImage(
+    model_config=ModelConfig.lens_turbo(),
+    quantize=8,
+)
+image = model.generate_image(
+    seed=7,
+    prompt="A cozy bookshop cafe at dusk, warm light through the window, a cat sleeping on a stack of books",
+    width=512,
+    height=512,
+    num_inference_steps=4,
+)
+image.save(path="lens.png")
+```
+
+</details>


### PR DESCRIPTION
## What

The README models table is missing the two most recent additions: Lens (#510) and Boogu Image (#446). Neither model had a `src/mflux/models/<name>/README.md` either, which every row in the table links to. This adds both rows, both per-model READMEs (following the krea2/z_image structure), acknowledgement lines for Microsoft/Comfy-Org and the Boogu team, and fixes a "qaility" typo in the FLUX.2 row.

The per-model READMEs document what the CLIs actually do: the ignored options each one warns about (guidance/negative prompt on both, scheduler on Lens), no LoRA flags on either, quantization support, and Boogu's step guidance at 1024px (taken from the CLI's own description).

## Checklist (definition of done)

- [NA] Tests added/updated run in CI by default — docs only, no code changed.
- [NA] `ruff check` and `ruff format` are clean — no Python touched; `typos` passes on the three files.
- [NA] `CHANGELOG.md` — docs only.
- [x] Docs updated where behavior changed — this PR is the docs update; no behavior changed.
- [NA] New model.
- [NA] New/changed CLI.

## Verification

Both README example commands were run verbatim on an M5 Max with real weights and the outputs inspected:

- `mflux-generate-boogu` (768x768, seed 42, 4 steps, q8): 21s of denoising, peak 18.2 GB. Prompt fully realized (night vendor, lanterns, steam, neon reflections on wet pavement, legible CJK signage).
- `mflux-generate-lens` (512x512, seed 7, 4 steps, q8): ~5s of denoising, peak 12.7 GB. Prompt fully realized (cat asleep on a stack of books, warm dusk light through the window).

Python API snippets mirror the exact constructor and `generate_image` kwargs used by each CLI (`ModelConfig.lens_turbo()` / `ModelConfig.boogu_image_turbo()` verified present; quantize choices verified as 3/4/5/6/8 from `QUANTIZE_CHOICES`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the Lens Turbo and Boogu Image Turbo models.
  * Included usage examples, supported settings, quantization details, and model limitations.
  * Updated the models list and corrected the FLUX.2 description.
  * Added acknowledgements for Microsoft, Comfy-Org, and the Boogu team.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents the Lens and Boogu Image model families and adds them to the main model table.
- Adds CLI and Python API examples for both models.
- Documents supported quantization, ignored options, and model-specific behavior.
- Adds project acknowledgements and corrects the FLUX.2 table typo.
</details>

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds model-table entries and acknowledgements for Lens and Boogu Image while correcting a typo. |
| src/mflux/models/boogu/README.md | Adds Boogu Image usage, quantization, limitations, and Python API documentation consistent with the repository implementation. |
| src/mflux/models/lens/README.md | Adds Lens usage, weight composition, quantization, limitations, and Python API documentation consistent with the repository implementation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: lens weights come from three repos..."](https://github.com/mflux-community/mflux/commit/a8a0490a4de8f840810e25fdd8865ffa0d5a3154) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54645983)</sub>

<!-- /greptile_comment -->