### PR TITLE
release: prepare 0.19.1 (version bump + CHANGELOG)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,17 @@ repos:
         # --all-extras: pytest etc. live in the dev extra, which isolated mode
         # would otherwise omit (making tests/ imports unresolvable).
         args: [--isolated, --no-python-downloads, --all-extras]
+  - repo: local
+    hooks:
+      # A pyproject.toml (or uv.lock) change must leave the lockfile consistent:
+      # `uv sync --locked` fails if uv.lock is out of date with pyproject.toml,
+      # and syncs .venv to the lock so the working environment matches the commit.
+      # Note: invoke pre-commit directly (as the installed git hook does), not via
+      # `uv run pre-commit` — `uv run` re-locks and rewrites uv.lock before the
+      # hook executes, which masks exactly the drift this hook exists to catch.
+      - id: uv-sync-locked
+        name: uv sync --locked
+        entry: uv sync --locked
+        language: system
+        files: ^(pyproject\.toml|uv\.lock)$
+        pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.19.1] - 2026-08-20
 
 ### 🔒 Security
 
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Shell completions cover every installed command**: the generator's hand-maintained list had drifted six commands behind pyproject (`mflux-generate-boogu`, `mflux-generate-lens`, both `mflux-generate-ernie-image` commands, `mflux-generate-ideogram4`, `mflux-capabilities` never completed). Commands are now discovered from the installed console scripts and, where a CLI exposes `build_parser()`, completions are generated from the CLI's real parser instead of a hand-copied recipe of it. (#578, #651)
 - **`mflux-capabilities` publishes wire types, not Python converter names**: options validated by a named converter leaked the function name as their type (`--vae-tile-size` claimed type `vae_tile_size`, `--mlx-cache-limit-gb` claimed `positive_float`, every Path option claimed `PosixPath`). Named converters now map to what they yield: `int`, `float`, `path`, and `int-or-scale` for values that accept a pixel count, a `2x` factor or `auto`. The dump's type field is pinned to that closed vocabulary by a test. (#578, #652)
+
+### 📝 Documentation
+
+- **Lens and Boogu Image documented**: both models join the README's supported-models table, each with a per-model README covering usage and options. (#659)
+
+### 🧰 DX & Maintenance
+
+- **Machine-readable model registry extract**: a new `scripts/ci_extract_models.py` (with a `ci-extract` workflow and `just` recipe) dumps the supported-model registry as JSON, needed by CI to auto-build MFlux models for Hugging Face. (#658)
+- **PyPI publish gated behind a protected `pypi` environment**: the release workflow now runs under the `pypi` deployment environment, so its reviewer-approval and branch-protection rules apply before anything reaches PyPI, and the trusted publisher is pinned to that environment name. A fast-fail step also rejects dispatches from any ref other than `main`. (#646)
+- **Lens DiT loads through the shared `WeightDefinition` seam**: replaces its bespoke weight-loading path with the mechanism the other models use. (#654)
+- **Flaky Gemma 2 causality test fixed**: the test could pick an out-of-vocab token and fail spuriously. (#653)
 
 ## [0.19.0] - 2026-08-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ source-exclude = [
 
 [project]
 name = "mflux"
-version = "0.19.0"
+version = "0.19.1"
 description = "MLX native implementations of state-of-the-art generative image models."
 readme = "README.md"
 keywords = ["flux", "ai", "ml", "transformers", "mlx", "huggingface", "apple-silicon", "diffusers", "qwen", "qwen-image", "seedvr2", "z-image"]

--- a/uv.lock
+++ b/uv.lock
@@ -1010,7 +1010,7 @@ wheels = [
 
 [[package]]
 name = "mflux"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
This will also be a first test of the hardened release process from #646 

## What

Prepares the 0.19.1 patch release: bumps `pyproject.toml` to `0.19.1` and cuts the `CHANGELOG.md` entry. The changelog renames the `Unreleased` section to `[0.19.1] - 2026-08-20` (keeping the already-written Security #655 and Bug Fixes #651/#652 entries) and adds the remaining commits since v.0.19.0 that had no entry: Lens/Boogu docs (#659), the CI model-registry JSON extract (#658), the protected `pypi` release environment (#646), the Lens `WeightDefinition` refactor (#654), and the flaky Gemma 2 test fix (#653).

Also syncs `uv.lock` to the 0.19.1 version bump and adds a `uv-sync-locked` pre-commit hook (local, `language: system`) that runs `uv sync --locked` whenever `pyproject.toml` or `uv.lock` is staged, so a manifest change can no longer land with a stale lockfile — exactly the drift this branch hit. The hook's comment warns against invoking hooks via `uv run pre-commit`, since `uv run` re-locks and rewrites `uv.lock` before hooks execute, masking the drift the hook exists to catch.

## Checklist (definition of done)

- [ ] Tests added/updated run in CI by default (selector: `-m "not slow and not high_memory_requirement"`, same as `just test`). Only mark `@pytest.mark.slow` or `@pytest.mark.high_memory_requirement` when a test exceeds CI's time or memory budget (typically weight downloads / image generation). — N/A: version bump + changelog only.
- [x] `ruff check` and `ruff format` are clean (`uv run ruff` uses the version pinned in the dev dependencies of `pyproject.toml`, which is the single source of truth for pre-commit and CI; `pre-commit run -a` covers it locally).
- [x] `CHANGELOG.md`: entry under `Unreleased` referencing this PR number. — This PR is the changelog cut itself; every entry in `[0.19.1]` references its source PR.
- [ ] Docs updated where behavior changed — README examples/table rows are part of the API contract (see `.cursor/rules/RULE.md`). — N/A: no behavior change.
- [ ] New model: shared config wiring (aliases, default steps, mflux-save dispatch, capabilities, completions), thin CLI entrypoint, and `src/mflux/models/<name>/README.md`. — N/A.
- [ ] New/changed CLI: ignored/rejected options declared (`IGNORED_OPTIONS`/`REJECTED_OPTIONS`) and `warn_ignored_options` actually called in `main()` — `mflux-capabilities` must stay truthful. — N/A.

## Verification

- `uv run pre-commit run --files CHANGELOG.md pyproject.toml` — typos and ty pass (ruff skipped: no Python files touched).
- Cross-checked every commit in `git log v.0.19.0..HEAD` has a changelog entry, and verified the #646 entry against the actual `release.yml` diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - Released version 0.19.1 on August 20, 2026.

- **Security**
  - Includes security updates and protected package publishing improvements.

- **Improvements**
  - Improved shell completion and capability handling.
  - Added shared model-weight loading support.
  - Extracted model-registry functionality.

- **Documentation**
  - Updated Lens and Boogu documentation.

- **Bug Fixes**
  - Improved Gemma 2 validation and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Hook verified both ways: with pyproject/uv.lock in sync `uv-sync-locked` passes; with a dependency constraint changed and the lock left stale it fails with uv's "lockfile needs to be updated" error. `pre-commit validate-config` passes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the 0.19.1 release and hardens local lockfile-consistency checks.
- Bumps the project and editable lockfile package versions to 0.19.1.
- Cuts the 0.19.1 changelog with documentation, maintenance, security, and bug-fix entries.
- Adds a pre-commit hook that runs `uv sync --locked` when the project manifest or lockfile changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .pre-commit-config.yaml | Adds a local lock-consistency hook for pyproject.toml and uv.lock changes. |
| CHANGELOG.md | Cuts the 0.19.1 release section and records the remaining release changes. |
| pyproject.toml | Updates the project version from 0.19.0 to 0.19.1. |
| uv.lock | Updates the editable mflux package version to 0.19.1, resolving the previously reported lockfile mismatch. |

</details>

<sub>Reviews (3): Last reviewed commit: ["ci: pre-commit hook asserts uv.lock is i..."](https://github.com/mflux-community/mflux/commit/a0529cbdec710ceb51aeed1079470e4f89bc5975) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54651222)</sub>

<!-- /greptile_comment -->