### PR TITLE
training: record the free per-step loss, batch metric behind an optional plot_frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ✨ Improvements
+
+- **Training loss monitoring no longer taxes the run**: the loop computed a loss every step and discarded it, then paid up to 10 extra forward passes per plot tick for a smoothed re-read of training samples; with `plot_frequency: 1` that tripled wall time (5.4 vs 17.5 s/step on a Krea 2 Raw QLoRA, the 80 vs 232 hour run of #671). The already-computed value now feeds the loss curve every step for free, the batch metric became an optional second series at `plot_frequency` ticks, and `plot_frequency` is optional with a default of 20. Checkpoint loss statistics carry both series; a legacy checkpoint's single series loads as the batch metric it was. (#671, #672)
+
 ## [0.19.1] - 2026-08-20
 
 ### 🔒 Security

--- a/src/mflux/models/common/training/_example/train.json
+++ b/src/mflux/models/common/training/_example/train.json
@@ -24,7 +24,7 @@
   "monitoring": {
     "preview_width": 1280,
     "preview_height": 720,
-    "plot_frequency": 1,
+    "plot_frequency": 20,
     "generate_image_frequency": 15
   },
   "lora_layers": {

--- a/src/mflux/models/common/training/state/training_spec.py
+++ b/src/mflux/models/common/training/state/training_spec.py
@@ -205,7 +205,9 @@ class MonitoringSpec:
         if preview_width <= 0 or preview_height <= 0:
             raise ValueError("Monitoring preview_width/preview_height must be > 0")
 
-        plot_frequency = int(param["plot_frequency"])
+        # Optional since #671: 20 keeps the batch metric's extra forwards at ~10-15% of
+        # wall time, against ~3x at 1. The free per-step series records regardless.
+        plot_frequency = int(param.get("plot_frequency", 20))
         generate_image_frequency = int(param["generate_image_frequency"])
         if plot_frequency <= 0:
             raise ValueError("Monitoring plot_frequency must be > 0")

--- a/src/mflux/models/common/training/statistics/plotter.py
+++ b/src/mflux/models/common/training/statistics/plotter.py
@@ -13,7 +13,7 @@ class Plotter:
     @staticmethod
     def update_loss_plot(training_spec: TrainingSpec, training_state: TrainingState, target_loss: float = 0.3) -> None:
         stats = training_state.statistics
-        if not stats.steps or not stats.losses:
+        if not stats.steps and not stats.batch_steps:
             return
 
         total_step = int(training_state.iterator.total_number_of_steps())
@@ -28,7 +28,9 @@ class Plotter:
 
         steps = [int(step) for step in stats.steps]
         losses = [float(loss) for loss in stats.losses]
-        max_x = max(steps)
+        batch_steps = [int(step) for step in stats.batch_steps]
+        batch_losses = [float(loss) for loss in stats.batch_losses]
+        max_x = max(steps + batch_steps)
         initial_padding = 0.4
         final_padding = 0.01
         padding_limit = initial_padding - (initial_padding - final_padding) * (max_x / total_step)
@@ -56,6 +58,8 @@ class Plotter:
         data = {
             "steps": steps,
             "losses": losses,
+            "batchSteps": batch_steps,
+            "batchLosses": batch_losses,
             "smoothed": smoothed,
             "smoothEnabled": smooth_loss,
             "previewMap": preview_step_to_src,
@@ -300,6 +304,13 @@ class Plotter:
               <span class="toggle-slider"></span>
             </label>
           </div>
+          <div class="control-row" id="batch-control">
+            <span>Batch</span>
+            <label class="toggle">
+              <input type="checkbox" id="toggle-batch" checked />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
         </div>
         <div class="chart-wrap" id="chart-wrap">
           <canvas id="chart"></canvas>
@@ -318,6 +329,8 @@ class Plotter:
       const previewToggle = document.getElementById('toggle-previews');
       const smoothToggle = document.getElementById('toggle-smooth');
       const smoothControl = document.getElementById('smooth-control');
+      const batchToggle = document.getElementById('toggle-batch');
+      const batchControl = document.getElementById('batch-control');
       const popover = document.getElementById('popover');
       function buildPopoverHTML(step, loss, src) {{
         const img = src ? '<img src="' + src + '" alt="" />' : '';
@@ -331,10 +344,13 @@ class Plotter:
       const dpr = window.devicePixelRatio || 1;
       const steps = data.steps;
       const losses = data.losses;
+      const batchSteps = data.batchSteps || [];
+      const batchLosses = data.batchLosses || [];
       const smoothed = data.smoothed || [];
       const smoothEnabled = data.smoothEnabled || false;
       let showSmoothed = smoothEnabled;
       let showLoss = true;
+      let showBatch = true;
       const previewMapAll = data.previewMap || {{}};
       const lossByStep = data.lossByStep || {{}};
       const previewSteps = data.previewSteps || [];
@@ -466,16 +482,18 @@ class Plotter:
       }}
 
       function draw() {{
-        if (!steps.length) return;
+        if (!steps.length && !batchSteps.length) return;
         const width = canvas.width / dpr - margin.left - margin.right;
         const height = canvas.height / dpr - margin.top - margin.bottom;
         ctx.clearRect(0, 0, canvas.width, canvas.height);
         ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--panel').trim();
         ctx.fillRect(0, 0, canvas.width / dpr, canvas.height / dpr);
 
-        const minStep = Math.min(...steps);
-        const maxStep = Math.max(...steps) + data.padding;
-        const allY = smoothed.length ? losses.concat(smoothed) : losses;
+        const allSteps = steps.concat(batchSteps);
+        const minStep = Math.min(...allSteps);
+        const maxStep = Math.max(...allSteps) + data.padding;
+        let allY = smoothed.length ? losses.concat(smoothed) : losses.slice();
+        allY = allY.concat(batchLosses);
         let minY = Math.min(...allY);
         let maxY = Math.max(...allY);
         if (minY === maxY) {{
@@ -520,6 +538,24 @@ class Plotter:
           ctx.lineWidth = 2;
           linePath(smoothPoints);
           ctx.setLineDash([]);
+        }}
+
+        if (showBatch && batchSteps.length) {{
+          const batchPoints = batchSteps.map((step, i) => {{
+            return {{
+              x: scaleX(step, minStep, maxStep, width),
+              y: scaleY(batchLosses[i], minY, maxY, height),
+            }};
+          }});
+          ctx.strokeStyle = '#C08A2D';
+          ctx.lineWidth = 2;
+          linePath(batchPoints);
+          batchPoints.forEach((p) => {{
+            ctx.beginPath();
+            ctx.fillStyle = '#C08A2D';
+            ctx.arc(p.x, p.y, 3.5, 0, Math.PI * 2);
+            ctx.fill();
+          }});
         }}
 
         if (showLoss) {{
@@ -697,6 +733,16 @@ class Plotter:
       if (smoothToggle) {{
         smoothToggle.checked = showSmoothed;
         smoothToggle.addEventListener('change', updateSmoothVisibility);
+      }}
+      if (batchControl) {{
+        batchControl.style.display = batchSteps.length ? 'flex' : 'none';
+      }}
+      if (batchToggle) {{
+        batchToggle.checked = showBatch;
+        batchToggle.addEventListener('change', () => {{
+          showBatch = batchToggle.checked;
+          draw();
+        }});
       }}
       window.addEventListener('resize', resize);
       resize();

--- a/src/mflux/models/common/training/statistics/statistics.py
+++ b/src/mflux/models/common/training/statistics/statistics.py
@@ -10,9 +10,15 @@ from mflux.models.common.training.state.zip_util import ZipUtil
 
 class Statistics:
     def __init__(self):
+        # Per-step training loss: the value the train step already computed, recorded free.
         self.steps: list[int] = []
         self.losses: list[float] = []
         self.times: list[datetime.datetime] = []
+        # Batch metric: an extra forward over up to 10 training samples at plot_frequency
+        # ticks. Smoother, but each point costs real time (#671).
+        self.batch_steps: list[int] = []
+        self.batch_losses: list[float] = []
+        self.batch_times: list[datetime.datetime] = []
 
     @staticmethod
     def from_spec(training_spec: TrainingSpec) -> "Statistics":
@@ -25,22 +31,43 @@ class Statistics:
             filename=training_spec.statistics.state_path,
             loader=lambda x: json.load(open(x, "r")),
         )
-        for entry in data:
-            stats.steps.append(entry["step"])
-            stats.losses.append(entry["loss"])
-            stats.times.append(datetime.datetime.strptime(entry["time"], "%Y-%m-%d %H:%M:%S"))
+        if isinstance(data, list):
+            # Pre-two-series checkpoint: its single series was the per-tick batch metric.
+            Statistics._load_entries(data, stats.batch_steps, stats.batch_losses, stats.batch_times)
+        else:
+            Statistics._load_entries(data.get("step_loss", []), stats.steps, stats.losses, stats.times)
+            Statistics._load_entries(data.get("batch_loss", []), stats.batch_steps, stats.batch_losses, stats.batch_times)  # fmt: off
 
         return stats
+
+    @staticmethod
+    def _load_entries(entries, steps: list[int], losses: list[float], times: list[datetime.datetime]) -> None:
+        for entry in entries:
+            steps.append(entry["step"])
+            losses.append(entry["loss"])
+            times.append(datetime.datetime.strptime(entry["time"], "%Y-%m-%d %H:%M:%S"))
 
     def append_values(self, step: int, loss: float) -> None:
         self.steps.append(step)
         self.losses.append(loss)
         self.times.append(datetime.datetime.now())
 
-    def save(self, path: Path) -> None:
-        loss_entries = [
+    def append_batch_values(self, step: int, loss: float) -> None:
+        self.batch_steps.append(step)
+        self.batch_losses.append(loss)
+        self.batch_times.append(datetime.datetime.now())
+
+    @staticmethod
+    def _entries(steps: list[int], losses: list[float], times: list[datetime.datetime]) -> list[dict]:
+        return [
             {"step": step, "loss": float(loss), "time": time.strftime("%Y-%m-%d %H:%M:%S")}
-            for step, loss, time in zip(self.steps, self.losses, self.times)
+            for step, loss, time in zip(steps, losses, times)
         ]
+
+    def save(self, path: Path) -> None:
+        document = {
+            "step_loss": Statistics._entries(self.steps, self.losses, self.times),
+            "batch_loss": Statistics._entries(self.batch_steps, self.batch_losses, self.batch_times),
+        }
         with open(path, "w", encoding="utf-8") as file:
-            json.dump(loss_entries, file, indent=4)
+            json.dump(document, file, indent=4)

--- a/src/mflux/models/common/training/trainer.py
+++ b/src/mflux/models/common/training/trainer.py
@@ -151,7 +151,7 @@ class TrainingTrainer:
             TrainingTrainer._generate_previews_with_optimizer_offload(adapter, training_spec, training_state)
             validation_batch = training_state.iterator.get_validation_batch()
             validation_loss = TrainingTrainer.compute_loss(adapter, training_spec, base_config, validation_batch)
-            training_state.statistics.append_values(step=training_state.iterator.num_iterations, loss=float(validation_loss))  # fmt: off
+            training_state.statistics.append_batch_values(step=training_state.iterator.num_iterations, loss=float(validation_loss))  # fmt: off
             Plotter.update_loss_plot(training_spec=training_spec, training_state=training_state)
             del validation_loss
             training_state.save(adapter, training_spec)
@@ -179,6 +179,8 @@ class TrainingTrainer:
                 if training_spec.low_ram:
                     mx.clear_cache()
                 continue
+            # The step already computed this; recording it costs nothing (#671).
+            train_loss = float(loss)
             del loss
 
             # Gradient accumulation: average grads across accum_steps micro-batches and only step
@@ -201,12 +203,18 @@ class TrainingTrainer:
                 mx.eval(accumulated_grads)
             del grads
 
-            if training_state.should_plot_loss(training_spec):
-                validation_batch = training_state.iterator.get_validation_batch()
-                validation_loss = TrainingTrainer.compute_loss(adapter, training_spec, base_config, validation_batch)
-                training_state.statistics.append_values(step=training_state.iterator.num_iterations, loss=float(validation_loss))  # fmt: off
+            if training_spec.monitoring is not None:
+                training_state.statistics.append_values(step=training_state.iterator.num_iterations, loss=train_loss)
+                if training_state.should_plot_loss(training_spec):
+                    # The batch metric pays an extra forward over up to 10 samples of the
+                    # training set: smoother than the per-step series, not held-out signal.
+                    validation_batch = training_state.iterator.get_validation_batch()
+                    validation_loss = TrainingTrainer.compute_loss(
+                        adapter, training_spec, base_config, validation_batch
+                    )
+                    training_state.statistics.append_batch_values(step=training_state.iterator.num_iterations, loss=float(validation_loss))  # fmt: off
+                    del validation_loss
                 Plotter.update_loss_plot(training_spec=training_spec, training_state=training_state)
-                del validation_loss
 
             if training_state.should_generate_image(training_spec):
                 TrainingTrainer._generate_previews_with_optimizer_offload(adapter, training_spec, training_state)

--- a/src/mflux/models/flux2/README.md
+++ b/src/mflux/models/flux2/README.md
@@ -136,7 +136,7 @@ Example (base model defaults to 50 steps):
   "optimizer": { "name": "AdamW", "learning_rate": 1e-4 },
   "checkpoint": { "output_path": "train", "save_frequency": 25 },
   "monitoring": {
-    "plot_frequency": 1,
+    "plot_frequency": 20,
     "generate_image_frequency": 20
   },
   "lora_layers": {

--- a/src/mflux/models/z_image/README.md
+++ b/src/mflux/models/z_image/README.md
@@ -107,7 +107,7 @@ Example:
   "optimizer": { "name": "AdamW", "learning_rate": 1e-4 },
   "checkpoint": { "output_path": "training", "save_frequency": 30 },
   "monitoring": {
-    "plot_frequency": 1,
+    "plot_frequency": 20,
     "generate_image_frequency": 30
   },
   "lora_layers": {

--- a/tests/training/test_loss_series.py
+++ b/tests/training/test_loss_series.py
@@ -1,0 +1,82 @@
+import json
+
+import pytest
+
+from mflux.models.common.training.state.training_spec import MonitoringSpec
+from mflux.models.common.training.statistics.statistics import Statistics
+
+
+@pytest.mark.fast
+def test_statistics_saves_both_series(tmp_path):
+    stats = Statistics()
+    stats.append_values(step=1, loss=0.5)
+    stats.append_values(step=2, loss=0.4)
+    stats.append_batch_values(step=20, loss=0.45)
+
+    path = tmp_path / "loss.json"
+    stats.save(path)
+    document = json.load(open(path))
+
+    assert [e["step"] for e in document["step_loss"]] == [1, 2]
+    assert [e["loss"] for e in document["step_loss"]] == [0.5, 0.4]
+    assert [e["step"] for e in document["batch_loss"]] == [20]
+
+
+@pytest.mark.fast
+def test_statistics_loads_both_series(monkeypatch, tmp_path):
+    stats = Statistics()
+    stats.append_values(step=1, loss=0.5)
+    stats.append_batch_values(step=20, loss=0.45)
+    path = tmp_path / "loss.json"
+    stats.save(path)
+
+    document = json.load(open(path))
+    reloaded = Statistics()
+    Statistics._load_entries(document["step_loss"], reloaded.steps, reloaded.losses, reloaded.times)
+    Statistics._load_entries(document["batch_loss"], reloaded.batch_steps, reloaded.batch_losses, reloaded.batch_times)
+
+    assert reloaded.steps == [1] and reloaded.losses == [0.5]
+    assert reloaded.batch_steps == [20] and reloaded.batch_losses == [0.45]
+
+
+@pytest.mark.fast
+def test_legacy_single_series_checkpoint_loads_as_batch_metric(monkeypatch):
+    # Pre-two-series checkpoints hold one flat list, and those entries were the
+    # per-tick batch metric, so a resumed run must not graft them onto the new
+    # per-step series.
+    from types import SimpleNamespace
+
+    from mflux.models.common.training.statistics import statistics as statistics_module
+
+    legacy = [{"step": 10, "loss": 0.6, "time": "2026-08-01 10:00:00"}]
+    monkeypatch.setattr(statistics_module.ZipUtil, "unzip", lambda **kwargs: legacy)
+    fake_spec = SimpleNamespace(
+        statistics=SimpleNamespace(state_path="loss.json"),
+        checkpoint_path="checkpoint.zip",
+    )
+
+    stats = Statistics.from_spec(fake_spec)
+
+    assert stats.batch_steps == [10]
+    assert stats.batch_losses == [0.6]
+    assert stats.steps == []
+
+
+@pytest.mark.fast
+def test_plot_frequency_is_optional_and_defaults_to_20():
+    spec = MonitoringSpec.create(
+        {"generate_image_frequency": 15},
+        preview_prompts=["a prompt"],
+        preview_prompt_names=["01"],
+    )
+    assert spec.plot_frequency == 20
+
+
+@pytest.mark.fast
+def test_explicit_plot_frequency_still_wins():
+    spec = MonitoringSpec.create(
+        {"plot_frequency": 3, "generate_image_frequency": 15},
+        preview_prompts=["a prompt"],
+        preview_prompt_names=["01"],
+    )
+    assert spec.plot_frequency == 3


### PR DESCRIPTION
## What

Fixes #671, with the shape agreed there: the training loss the step already computed is now recorded every step for free, the batch metric became a second series behind `plot_frequency`, and `plot_frequency` is optional with a default of 20.

- The loop captured its loss and discarded it unrecorded, then paid up to 10 extra forwards per plot tick for a smoothed re-read of training samples. The free value now feeds the primary series, every step, and `loss.html` refreshes per step.
- The batch metric stays for whoever wants the smoother curve: same computation, its own series, rendered as a second line with a toggle, at `plot_frequency` ticks. The initial pre-training point stays too.
- `plot_frequency` was required; it now defaults to 20 (both ernie examples already shipped that). The z-image and flux2 examples shipped 1 and are now 20.
- Checkpoint statistics moved from a flat list to `{"step_loss": [...], "batch_loss": [...]}`. A legacy checkpoint loads its single series as the batch metric, which is what those entries were.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default: statistics save/load for both series, legacy checkpoint load through `from_spec`, and the `plot_frequency` default and explicit-value paths.
- [x] `ruff check` and `ruff format` are clean.
- [x] `CHANGELOG.md`: entry under `Unreleased` (follow-up commit referencing this PR number).
- [x] Docs updated where behavior changed: the three example configs.
- [ ] New model.
- [ ] New/changed CLI.

## Verification

Krea 2 Raw QLoRA on an M5 Max (q8 base, 512px, 10-image dataset, rank 16, 10 steps, same seed):

| | s/step |
|---|---|
| before, plotting effectively off | 5.41 |
| before, `plot_frequency: 1` | 17.47 |
| after, `plot_frequency` omitted (default 20) | 5.43 |

The per-step recording and per-step `loss.html` refresh cost nothing measurable. Inspected the run's artifacts: `loss.html` carries the 10-point step series plus the initial batch point, and the checkpoint's loss file has both keys.

Full suite with the CI selector: 1475 passed.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR separates training statistics into per-step and periodic batch-loss series while making `plot_frequency` optional with a default of 20.
- Records the already-computed training loss after every finite monitored step.
- Preserves periodic batch-loss measurements and legacy checkpoint compatibility.
- Updates the HTML plot to render and toggle both series.
- Updates example configurations, documentation, and statistics tests.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The new metric lifecycle follows existing micro-batch step semantics, preserves legacy checkpoint data in the appropriate batch series, and handles empty or mixed series in the plotter.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mflux/models/common/training/trainer.py | Records each finite micro-batch loss and retains the frequency-gated batch metric without introducing an additional MLX synchronization. |
| src/mflux/models/common/training/statistics/statistics.py | Introduces separate persisted step and batch series while mapping legacy flat checkpoints to the batch series. |
| src/mflux/models/common/training/statistics/plotter.py | Supports plotting either or both loss series and adds a batch-series visibility toggle. |
| src/mflux/models/common/training/state/training_spec.py | Defaults omitted monitoring plot frequency to 20 while retaining positive-value validation. |
| tests/training/test_loss_series.py | Covers serialization, legacy loading, and default or explicit plot-frequency behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Training micro-batch] --> B[Compute loss and gradients]
    B --> C{Loss finite?}
    C -- No --> D[Reset accumulation and skip]
    C -- Yes --> E[Record step-loss point]
    E --> F{plot_frequency reached?}
    F -- Yes --> G[Compute and record batch-loss point]
    F -- No --> H[Refresh loss plot]
    G --> H
    H --> I{Checkpoint due?}
    I -- Yes --> J[Save both loss series]
    I -- No --> A
    J --> A
```
</details>

<sub>Reviews (1): Last reviewed commit: ["training: record the free per-step loss,..."](https://github.com/mflux-community/mflux/commit/f2e78519be4ecb3ffd527e8a781f6e18c7cb702e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56852500)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training charts now distinguish step loss from batch loss, with an optional Batch visibility toggle.
  * Monitoring plot frequency defaults to every 20 steps and can be customized.
  * Existing training checkpoints remain compatible with the updated loss format.

* **Bug Fixes**
  * Reduced the overhead of training-loss monitoring by limiting plot generation frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->