### PR TITLE
ci: keep dynamic values out of shell source in release and ci-extract

### DIFF
--- a/.github/workflows/ci-extract.yml
+++ b/.github/workflows/ci-extract.yml
@@ -68,6 +68,9 @@ jobs:
         if: steps.dest.outputs.sync == 'true'
         env:
           HF_TOKEN: ${{ secrets.HF_CI_BUCKET_TOKEN }}
+          # Routed through env rather than expanded into the script; the value is
+          # built from repo/owner names today, the hygiene keeps it that way.
+          DEST: ${{ steps.dest.outputs.path }}
         run: >
           uvx --from 'huggingface_hub>=1.13,<2'
-          hf sync .ci_cache "${{ steps.dest.outputs.path }}"
+          hf sync .ci_cache "$DEST"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,15 +25,21 @@ jobs:
         # Defense in depth: the pypi environment's deployment branch policy is
         # the primary gate; this fails fast with a clear message if dispatched
         # from any ref other than main.
+        # $GITHUB_REF is the runner-provided env var: unlike a ${{ }} template
+        # expansion, its value never becomes shell source (#646 review, #648).
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
-            echo "❌ Releases may only be published from main (got ${{ github.ref }})"
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "❌ Releases may only be published from main (got $GITHUB_REF)"
             exit 1
           fi
 
       - name: Validate confirmation
+        # The dispatch input is free text; passing it through env keeps it data
+        # instead of expanding it into the script (same class as the ref guard).
+        env:
+          CONFIRM: ${{ github.event.inputs.confirm }}
         run: |
-          if [ "${{ github.event.inputs.confirm }}" != "publish" ]; then
+          if [ "$CONFIRM" != "publish" ]; then
             echo "❌ Must type 'publish' to confirm release"
             exit 1
           fi


### PR DESCRIPTION
## What

Closes #648. I went through every CodeRabbit and Greptile suggestion on `.github/` from the recent workflow PRs (#576, #644, #646, #658, #660) and checked each against current main. Most were already applied inside their own PRs. One was not, and it's the important one: the shell-injection fix for `release.yml`'s branch guard that both bots flagged on #646 got resolved in the review threads as "Fixed in 62a2348", but that commit never made it into the squash. Main still template-expands `${{ github.ref }}` into the script.

This applies that fix, and the same treatment to the two remaining dynamic values expanded into `run` blocks: `github.event.inputs.confirm` in the release confirmation (free-text dispatch input, so the worse case of the class) and `steps.dest.outputs.path` in ci-extract (controlled charset today, routed through env as hygiene).

Skipped with reasons: the #658 routing suggestion stays as designed (dispatch on the canonical repo is the only manual way to refresh the production manifest), and `MFLUX_PRESERVE_TEST_OUTPUT=1` on the CI pytest run buys nothing while the runner discards the files; it would only make sense together with an artifact upload on failure, which can be its own conversation if anyone wants it.

## Checklist (definition of done)

- [ ] Tests added/updated run in CI by default. NA, workflow-only.
- [x] `ruff check` and `ruff format` are clean. No Python touched.
- [ ] `CHANGELOG.md`. NA, CI plumbing.
- [x] Docs updated where behavior changed. Nothing user-facing changed.
- [ ] New model. NA.
- [ ] New/changed CLI. NA.

## Verification

`actionlint` and YAML parsing are clean on all three workflows. `$GITHUB_REF` is runner-provided with the same value `github.ref` renders, so the guard's behavior is unchanged for legitimate refs; what changes is that a crafted ref or confirm value now stays data instead of becoming shell source. The release flow itself can only be exercised by the next real release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI and release workflow handling of destination paths, branch references, and dispatch confirmations.
  * Preserved release safeguards requiring the main branch and explicit publish confirmation.
  * Reduced potential issues caused by directly embedding workflow values in shell commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents dynamic GitHub Actions values from becoming shell source while preserving existing release validation and artifact-sync behavior.
- Routes the release confirmation input through an environment variable and uses the runner-provided `GITHUB_REF` for branch validation.
- Routes the computed Hugging Face destination through an environment variable before invoking `hf sync`.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable regressions identified.

The environment-variable routing preserves the exact release checks and destination values while preventing dynamic workflow data from being interpreted as shell source.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Safely moves branch and confirmation values out of shell source without changing the release gates. |
| .github/workflows/ci-extract.yml | Safely passes the computed Hugging Face destination through the environment while retaining the existing quoted argument and sync guard. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: keep dynamic values out of shell sou..."](https://github.com/mflux-community/mflux/commit/8aa8b266a600da3e33c7158fb6f36ce244015328) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56956277)</sub>

<!-- /greptile_comment -->