### PR TITLE
fix: give the Flux generation variants save_model, and make dev-redux saveable end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **Every Flux generation variant can save, and dev-redux is saveable end-to-end**: conversion tooling driving the model classes got `AttributeError: '...' object has no attribute 'save_model'` from every Flux variant but `Flux1`/`Flux1Controlnet`, and `mflux-save --model dev-redux` was dispatched to plain `Flux1`, whose base weights can never come from the Redux adapter repo. All Flux variants now have `save_model`, and the redux save writes a self-contained checkpoint (base FLUX.1 components plus the siglip image encoder and redux embedder) that `mflux-generate-redux` reads back from disk instead of the hub. Along the way this repairs `mflux-generate-redux` on default arguments, which crashed loading base weights from the adapter repo (it has no vae/transformer/text encoders — the base now resolves from FLUX.1-dev unless a checkpoint path says otherwise). (#667, #680)
+
 ### ✨ Improvements
 
 - **Training loss monitoring no longer taxes the run**: the loop computed a loss every step and discarded it, then paid up to 10 extra forward passes per plot tick for a smoothed re-read of training samples; with `plot_frequency: 1` that tripled wall time (5.4 vs 17.5 s/step on a Krea 2 Raw QLoRA, the 80 vs 232 hour run of #671). The already-computed value now feeds the loss curve every step for free, the batch metric became an optional second series at `plot_frequency` ticks, and `plot_frequency` is optional with a default of 20. Checkpoint loss statistics carry both series; a legacy checkpoint's single series loads as the batch metric it was. (#671, #672)

--- a/src/mflux/models/common/cli/save.py
+++ b/src/mflux/models/common/cli/save.py
@@ -10,6 +10,7 @@ from mflux.models.ernie_image.variants.txt2img.ernie_image import ErnieImage
 from mflux.models.fibo.variants.edit.fibo_edit import FIBOEdit
 from mflux.models.fibo.variants.txt2img.fibo import FIBO
 from mflux.models.flux.variants.controlnet.flux_controlnet import Flux1Controlnet
+from mflux.models.flux.variants.redux.flux_redux import Flux1Redux
 from mflux.models.flux.variants.txt2img.flux import Flux1
 from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
 from mflux.models.ideogram4.variants.txt2img.ideogram4 import Ideogram4
@@ -37,7 +38,7 @@ MODEL_CLASSES: dict[str, type] = {
     "dev-fill": Flux1,
     "dev-fill-catvton": Flux1,
     "dev-kontext": Flux1,
-    "dev-redux": Flux1,
+    "dev-redux": Flux1Redux,
     "ernie-image": ErnieImage,
     "ernie-image-turbo": ErnieImage,
     "fibo": FIBO,

--- a/src/mflux/models/flux/README.md
+++ b/src/mflux/models/flux/README.md
@@ -242,6 +242,19 @@ There is a tendency for the reference image to dominate over the input prompt.
 > [!WARNING]
 > Note: Using the Redux tool requires an additional 1.1GB download from [black-forest-labs/FLUX.1-Redux-dev](https://huggingface.co/black-forest-labs/FLUX.1-Redux-dev). The download happens automatically on first use.
 
+##### Saving a quantized Redux checkpoint
+
+`mflux-save --model dev-redux` writes a self-contained checkpoint: the base FLUX.1-dev weights plus the siglip image encoder and redux embedder (the two pieces the Redux repo adds), quantized together:
+
+```bash
+mflux-save \
+  --model dev-redux \
+  --path /Users/me/models/dev-redux_8bit \
+  --quantize 8
+```
+
+Load it back with `--model /Users/me/models/dev-redux_8bit`; the redux encoders are read from the checkpoint instead of the hub.
+
 ---
 
 ### 🎭 In-Context Generation

--- a/src/mflux/models/flux/flux_initializer.py
+++ b/src/mflux/models/flux/flux_initializer.py
@@ -75,20 +75,25 @@ class FluxInitializer:
         lora_scales: list[float] | None = None,
         bake_lora: bool = True,
     ) -> None:
+        # The dev-redux config names the Redux adapter repo, which ships only the siglip
+        # image encoder and the embedder — no vae/transformer/text encoders. It can never
+        # be the base-weights location, so default and `--model dev-redux` invocations
+        # fall back to FLUX.1-dev, the base Redux is defined on. An explicit model_path
+        # (a saved checkpoint or a repo id) always wins.
+        resolved_model_path = model_path or (
+            ModelConfig.dev().model_name if model_config is ModelConfig.dev_redux() else model_config.model_name
+        )
         FluxInitializer.init(
             model=model,
             quantize=quantize,
-            model_path=model_path,
+            model_path=resolved_model_path,
             lora_paths=lora_paths,
             lora_scales=lora_scales,
             bake_lora=bake_lora,
             model_config=model_config,
         )
 
-        redux_weights = WeightLoader.load(
-            weight_definition=FluxReduxWeightDefinition,
-            model_path=ModelConfig.dev_redux().model_name,
-        )
+        redux_weights = FluxInitializer._load_redux_weights(model_path)
         model.image_embedder = ReduxEncoder()
         model.image_encoder = SiglipVisionTransformer()
         WeightApplier.apply_and_quantize(
@@ -231,6 +236,25 @@ class FluxInitializer:
             lora_paths=lora_paths,
             lora_scales=lora_scales,
             bake_lora=bake_lora,
+        )
+
+    @staticmethod
+    def _load_redux_weights(model_path: str | None) -> LoadedWeights:
+        # A checkpoint written by mflux-save carries the redux encoders under
+        # image_encoder/ and image_embedder/; honor them so offline reloads work and
+        # saved weights (a -q quantization) are not silently swapped for the remote
+        # ones. A base-only checkpoint keeps the hub path for its missing encoders;
+        # a half-saved redux checkpoint loads locally and fails loudly on the missing
+        # half instead of silently mixing sources.
+        local_root = Path(model_path) if model_path is not None else None
+        if local_root is not None and (
+            any((local_root / "image_encoder").glob("*.safetensors"))
+            or any((local_root / "image_embedder").glob("*.safetensors"))
+        ):
+            return WeightLoader.load(weight_definition=FluxReduxWeightDefinition, model_path=str(local_root))
+        return WeightLoader.load(
+            weight_definition=FluxReduxWeightDefinition,
+            model_path=ModelConfig.dev_redux().model_name,
         )
 
     @staticmethod

--- a/src/mflux/models/flux/variants/depth/flux_depth.py
+++ b/src/mflux/models/flux/variants/depth/flux_depth.py
@@ -6,6 +6,7 @@ from mlx import nn
 from mflux.models.common.config.config import Config
 from mflux.models.common.config.model_config import ModelConfig
 from mflux.models.common.vae.vae_util import VAEUtil
+from mflux.models.common.weights.saving.model_saver import ModelSaver
 from mflux.models.depth_pro.model.depth_pro import DepthPro
 from mflux.models.flux.flux_initializer import FluxInitializer
 from mflux.models.flux.latent_creator.flux_latent_creator import FluxLatentCreator
@@ -15,6 +16,7 @@ from mflux.models.flux.model.flux_text_encoder.t5_encoder.t5_encoder import T5En
 from mflux.models.flux.model.flux_transformer.transformer import Transformer
 from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.models.flux.variants.depth.depth_util import DepthUtil
+from mflux.models.flux.weights.flux_weight_definition import FluxWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
 from mflux.utils.image_util import ImageUtil
@@ -152,4 +154,14 @@ class Flux1Depth(nn.Module):
             image_path=config.image_path,
             depth_image_path=config.depth_image_path,
             generation_time=config.time_steps.format_dict["elapsed"],
+        )
+
+    def save_model(self, base_path: str) -> None:
+        # Saves the FLUX.1-Depth weights (vae/transformer/text encoders) only: DepthPro
+        # is an auxiliary preprocessor constructed per init, not part of the checkpoint.
+        ModelSaver.save_model(
+            model=self,
+            bits=self.bits,
+            base_path=base_path,
+            weight_definition=FluxWeightDefinition,
         )

--- a/src/mflux/models/flux/variants/fill/flux_fill.py
+++ b/src/mflux/models/flux/variants/fill/flux_fill.py
@@ -6,6 +6,7 @@ from mlx import nn
 from mflux.models.common.config.config import Config
 from mflux.models.common.config.model_config import ModelConfig
 from mflux.models.common.vae.vae_util import VAEUtil
+from mflux.models.common.weights.saving.model_saver import ModelSaver
 from mflux.models.flux.flux_initializer import FluxInitializer
 from mflux.models.flux.latent_creator.flux_latent_creator import FluxLatentCreator
 from mflux.models.flux.model.flux_text_encoder.clip_encoder.clip_encoder import CLIPEncoder
@@ -14,6 +15,7 @@ from mflux.models.flux.model.flux_text_encoder.t5_encoder.t5_encoder import T5En
 from mflux.models.flux.model.flux_transformer.transformer import Transformer
 from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.models.flux.variants.fill.mask_util import MaskUtil
+from mflux.models.flux.weights.flux_weight_definition import FluxWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
 from mflux.utils.image_util import ImageUtil
@@ -151,4 +153,12 @@ class Flux1Fill(nn.Module):
             image_strength=config.image_strength,
             masked_image_path=config.masked_image_path,
             generation_time=config.time_steps.format_dict["elapsed"],
+        )
+
+    def save_model(self, base_path: str) -> None:
+        ModelSaver.save_model(
+            model=self,
+            bits=self.bits,
+            base_path=base_path,
+            weight_definition=FluxWeightDefinition,
         )

--- a/src/mflux/models/flux/variants/in_context/flux_in_context_dev.py
+++ b/src/mflux/models/flux/variants/in_context/flux_in_context_dev.py
@@ -7,6 +7,7 @@ from mflux.models.common.config.config import Config
 from mflux.models.common.config.model_config import ModelConfig
 from mflux.models.common.latent_creator.latent_creator import LatentCreator
 from mflux.models.common.vae.vae_util import VAEUtil
+from mflux.models.common.weights.saving.model_saver import ModelSaver
 from mflux.models.flux.flux_initializer import FluxInitializer
 from mflux.models.flux.latent_creator.flux_latent_creator import FluxLatentCreator
 from mflux.models.flux.model.flux_text_encoder.clip_encoder.clip_encoder import CLIPEncoder
@@ -14,6 +15,7 @@ from mflux.models.flux.model.flux_text_encoder.prompt_encoder import PromptEncod
 from mflux.models.flux.model.flux_text_encoder.t5_encoder.t5_encoder import T5Encoder
 from mflux.models.flux.model.flux_transformer.transformer import Transformer
 from mflux.models.flux.model.flux_vae.vae import VAE
+from mflux.models.flux.weights.flux_weight_definition import FluxWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
 from mflux.utils.image_util import ImageUtil
@@ -152,6 +154,14 @@ class Flux1InContextDev(nn.Module):
             image_path=config.image_path,
             image_strength=config.image_strength,
             generation_time=config.time_steps.format_dict["elapsed"],
+        )
+
+    def save_model(self, base_path: str) -> None:
+        ModelSaver.save_model(
+            model=self,
+            bits=self.bits,
+            base_path=base_path,
+            weight_definition=FluxWeightDefinition,
         )
 
     @staticmethod

--- a/src/mflux/models/flux/variants/in_context/flux_in_context_fill.py
+++ b/src/mflux/models/flux/variants/in_context/flux_in_context_fill.py
@@ -6,6 +6,7 @@ from mlx import nn
 from mflux.models.common.config.config import Config
 from mflux.models.common.config.model_config import ModelConfig
 from mflux.models.common.vae.vae_util import VAEUtil
+from mflux.models.common.weights.saving.model_saver import ModelSaver
 from mflux.models.flux.flux_initializer import FluxInitializer
 from mflux.models.flux.latent_creator.flux_latent_creator import FluxLatentCreator
 from mflux.models.flux.model.flux_text_encoder.clip_encoder.clip_encoder import CLIPEncoder
@@ -14,6 +15,7 @@ from mflux.models.flux.model.flux_text_encoder.t5_encoder.t5_encoder import T5En
 from mflux.models.flux.model.flux_transformer.transformer import Transformer
 from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.models.flux.variants.in_context.utils.in_context_mask_util import InContextMaskUtil
+from mflux.models.flux.weights.flux_weight_definition import FluxWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
 from mflux.utils.image_util import ImageUtil
@@ -157,4 +159,12 @@ class Flux1InContextFill(nn.Module):
             image_strength=config.image_strength,
             masked_image_path=config.masked_image_path,
             generation_time=config.time_steps.format_dict["elapsed"],
+        )
+
+    def save_model(self, base_path: str) -> None:
+        ModelSaver.save_model(
+            model=self,
+            bits=self.bits,
+            base_path=base_path,
+            weight_definition=FluxWeightDefinition,
         )

--- a/src/mflux/models/flux/variants/kontext/flux_kontext.py
+++ b/src/mflux/models/flux/variants/kontext/flux_kontext.py
@@ -6,6 +6,7 @@ from mlx import nn
 from mflux.models.common.config.config import Config
 from mflux.models.common.config.model_config import ModelConfig
 from mflux.models.common.vae.vae_util import VAEUtil
+from mflux.models.common.weights.saving.model_saver import ModelSaver
 from mflux.models.flux.flux_initializer import FluxInitializer
 from mflux.models.flux.latent_creator.flux_latent_creator import FluxLatentCreator
 from mflux.models.flux.model.flux_text_encoder.clip_encoder.clip_encoder import CLIPEncoder
@@ -14,6 +15,7 @@ from mflux.models.flux.model.flux_text_encoder.t5_encoder.t5_encoder import T5En
 from mflux.models.flux.model.flux_transformer.transformer import Transformer
 from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.models.flux.variants.kontext.kontext_util import KontextUtil
+from mflux.models.flux.weights.flux_weight_definition import FluxWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
 from mflux.utils.image_util import ImageUtil
@@ -151,4 +153,12 @@ class Flux1Kontext(nn.Module):
             lora_scales=self.lora_scales,
             image_path=config.image_path,
             generation_time=config.time_steps.format_dict["elapsed"],
+        )
+
+    def save_model(self, base_path: str) -> None:
+        ModelSaver.save_model(
+            model=self,
+            bits=self.bits,
+            base_path=base_path,
+            weight_definition=FluxWeightDefinition,
         )

--- a/src/mflux/models/flux/variants/redux/flux_redux.py
+++ b/src/mflux/models/flux/variants/redux/flux_redux.py
@@ -7,6 +7,7 @@ from mflux.models.common.config.config import Config
 from mflux.models.common.config.model_config import ModelConfig
 from mflux.models.common.tokenizer import Tokenizer
 from mflux.models.common.vae.vae_util import VAEUtil
+from mflux.models.common.weights.saving.model_saver import ModelSaver
 from mflux.models.flux.flux_initializer import FluxInitializer
 from mflux.models.flux.latent_creator.flux_latent_creator import FluxLatentCreator
 from mflux.models.flux.model.flux_text_encoder.clip_encoder.clip_encoder import CLIPEncoder
@@ -17,6 +18,7 @@ from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.models.flux.model.redux_encoder.redux_encoder import ReduxEncoder
 from mflux.models.flux.model.siglip_vision_transformer.siglip_vision_transformer import SiglipVisionTransformer
 from mflux.models.flux.variants.redux.redux_util import ReduxUtil
+from mflux.models.flux.weights.flux_weight_definition import FluxReduxSaveDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
 from mflux.utils.image_util import ImageUtil
@@ -148,6 +150,14 @@ class Flux1Redux(nn.Module):
             redux_image_strengths=config.redux_image_strengths,
             image_strength=config.image_strength,
             generation_time=config.time_steps.format_dict["elapsed"],
+        )
+
+    def save_model(self, base_path: str) -> None:
+        ModelSaver.save_model(
+            model=self,
+            bits=self.bits,
+            base_path=base_path,
+            weight_definition=FluxReduxSaveDefinition,
         )
 
     @staticmethod

--- a/src/mflux/models/flux/weights/flux_weight_definition.py
+++ b/src/mflux/models/flux/weights/flux_weight_definition.py
@@ -161,3 +161,20 @@ class FluxReduxWeightDefinition:
             if module.weight.shape[-1] % 64 != 0:
                 return False
         return hasattr(module, "to_quantized")
+
+
+class FluxReduxSaveDefinition:
+    """The complete checkpoint mflux-save writes for dev-redux: the base FLUX.1
+    components plus the redux encoders, mirroring how FluxControlnetWeightDefinition's
+    save list extends the base definition. Kept separate from FluxReduxWeightDefinition,
+    whose two components are only the encoders, loaded on top of an already-initialized
+    base. The same components serve both directions: ModelSaver writes each under its
+    hf_subdir, and WeightLoader reads the saved layout back from those same subdirs."""
+
+    @staticmethod
+    def get_components() -> List[ComponentDefinition]:
+        return FluxWeightDefinition.get_components() + FluxReduxWeightDefinition.get_components()
+
+    @staticmethod
+    def get_tokenizers() -> List[TokenizerDefinition]:
+        return FluxWeightDefinition.get_tokenizers()

--- a/tests/model_saving/test_save_cli_dispatch.py
+++ b/tests/model_saving/test_save_cli_dispatch.py
@@ -17,6 +17,12 @@ from mflux.models.common.cli import save
 from mflux.models.common.config.model_config import AVAILABLE_MODELS
 from mflux.models.common.resolution.config_resolution import ConfigResolution
 from mflux.models.fibo.variants.edit.fibo_edit import FIBOEdit
+from mflux.models.flux.variants.depth.flux_depth import Flux1Depth
+from mflux.models.flux.variants.fill.flux_fill import Flux1Fill
+from mflux.models.flux.variants.in_context.flux_in_context_dev import Flux1InContextDev
+from mflux.models.flux.variants.in_context.flux_in_context_fill import Flux1InContextFill
+from mflux.models.flux.variants.kontext.flux_kontext import Flux1Kontext
+from mflux.models.flux.variants.redux.flux_redux import Flux1Redux
 from mflux.models.flux.variants.txt2img.flux import Flux1
 from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
 from mflux.models.qwen.variants.txt2img.qwen_image import QwenImage
@@ -76,6 +82,18 @@ def test_every_save_class_can_save(model_class):
 
 
 @pytest.mark.fast
+@pytest.mark.parametrize(
+    "variant_class",
+    [Flux1Depth, Flux1Fill, Flux1Kontext, Flux1InContextFill, Flux1InContextDev, Flux1Redux],
+    ids=lambda c: c.__name__,
+)
+def test_every_flux_variant_class_can_save(variant_class):
+    # Conversion tooling (and the Python API generally) drives the generation classes
+    # directly; a variant without save_model is the AttributeError of issue #667.
+    assert hasattr(variant_class, "save_model")
+
+
+@pytest.mark.fast
 @pytest.mark.parametrize("name", ALL_NAMES)
 def test_every_name_dispatches_by_registry_entry(name):
     # Canonical keys and aliases alike go through ConfigResolution, so `klein-4b` and
@@ -98,6 +116,9 @@ def test_every_name_dispatches_by_registry_entry(name):
         ("fibo-edit", FIBOEdit),
         ("fiboedit-rmbg", FIBOEdit),
         ("z-image-controlnet", ZImageTurboControlnet),
+        # dev-redux must not be saved as plain Flux1: the Redux repo ships no base
+        # weights, so the save class is the one that also owns the encoders.
+        ("dev-redux", Flux1Redux),
         ("krea-dev", Flux1),  # still Flux.1, and not confused with krea-2
         ("Qwen/Qwen-Image-2512", QwenImage),  # repo ids resolve too, not just aliases
         ("/models/my-qwen-image-finetune", QwenImage),  # inferred from the path name

--- a/tests/model_saving/test_tiny_model_saving_flux_redux.py
+++ b/tests/model_saving/test_tiny_model_saving_flux_redux.py
@@ -1,0 +1,51 @@
+import mlx.nn as nn
+import pytest
+
+from mflux.models.flux.weights.flux_weight_definition import FluxReduxWeightDefinition
+from tests.model_saving.tiny_checkpoint_helper import TinyCheckpointRoundtrip
+
+
+class TinySiglipStandIn(nn.Module):
+    # Mirrors SiglipVisionTransformer's attribute roots (embeddings/encoder/post_layernorm/
+    # head) at tiny dimensions; fixed-size architectures get stand-ins per
+    # TinyCheckpointRoundtrip's TinyVAEStandIn precedent. The Conv2d exercises the
+    # definition's quantization_predicate exclusion, and the saved tree having no
+    # "vision_model" root exercises WeightApplier's weight_subkey fallback on reload.
+    def __init__(self) -> None:
+        super().__init__()
+        self.embeddings = nn.Conv2d(3, 64, kernel_size=3)
+        self.encoder = nn.Linear(1152, 1152)
+        self.post_layernorm = nn.LayerNorm(1152)
+        self.head = nn.Linear(1152, 128)
+
+
+class TinyReduxEncoderStandIn(nn.Module):
+    # Same attribute names as the real ReduxEncoder (redux_up/redux_down), small dims.
+    def __init__(self) -> None:
+        super().__init__()
+        self.redux_up = nn.Linear(64, 128)
+        self.redux_down = nn.Linear(128, 64)
+
+
+class TestTinyFluxReduxModelSaving:
+    @pytest.mark.fast
+    def test_tiny_quantized_checkpoint_roundtrips_exactly(self, tmp_path):
+        # The redux components are the save side of issue #667's dev-redux gap: saved
+        # under image_encoder/ and image_embedder/ (model_attr differs from the
+        # component names), reloaded through WeightLoader's mflux-format detection.
+        TinyCheckpointRoundtrip.save_and_reload_expecting_identical_weights(
+            weight_definition=FluxReduxWeightDefinition,
+            make_components=TestTinyFluxReduxModelSaving._tiny_components,
+            base_path=tmp_path / "flux_redux_tiny_q8",
+            bits=8,
+            # Force shard boundaries so index.json/weight_map multi-shard paths are
+            # exercised — the size-based split never shards test-sized tensors.
+            tensors_per_shard=2,
+        )
+
+    @staticmethod
+    def _tiny_components():
+        return {
+            "siglip": TinySiglipStandIn(),
+            "redux_encoder": TinyReduxEncoderStandIn(),
+        }

--- a/tests/weights/test_flux_redux_local_load.py
+++ b/tests/weights/test_flux_redux_local_load.py
@@ -1,0 +1,103 @@
+# A redux checkpoint written by mflux-save keeps its encoders under image_encoder/ and
+# image_embedder/. The initializer used to fetch them from the remote repo
+# unconditionally, so reloading a saved checkpoint silently swapped the saved (e.g. -q
+# quantized) encoder weights for the hub's and broke offline use. These tests pin the
+# routing decision, mirroring test_flux_controlnet_local_load.py: a checkpoint carrying
+# the redux subdirs loads them locally, everything else keeps the hub path.
+#
+# They also pin the base-weights location: the dev-redux config names the adapter repo
+# (encoder + embedder only), so without a model_path the base must come from FLUX.1-dev,
+# not from a repo that has no transformer/vae at all.
+
+import pytest
+
+from mflux.models.common.config.model_config import ModelConfig
+from mflux.models.common.weights.loading.weight_applier import WeightApplier
+from mflux.models.common.weights.loading.weight_loader import WeightLoader
+from mflux.models.flux.flux_initializer import FluxInitializer
+
+
+@pytest.fixture
+def loader_calls(monkeypatch):
+    seen = {}
+
+    def record(weight_definition, model_path=None, download_patterns=None):
+        seen["load"] = {"weight_definition": weight_definition, "model_path": model_path}
+        return "redux-weights"
+
+    monkeypatch.setattr(WeightLoader, "load", record)
+    return seen
+
+
+@pytest.mark.fast
+def test_a_saved_checkpoint_loads_its_own_redux_encoders(loader_calls, tmp_path):
+    (tmp_path / "image_encoder").mkdir()
+    (tmp_path / "image_encoder" / "0.safetensors").touch()
+    (tmp_path / "image_embedder").mkdir()
+    (tmp_path / "image_embedder" / "0.safetensors").touch()
+
+    weights = FluxInitializer._load_redux_weights(model_path=str(tmp_path))
+
+    assert loader_calls["load"]["model_path"] == str(tmp_path)
+    assert weights == "redux-weights"
+
+
+@pytest.mark.fast
+def test_a_half_saved_redux_checkpoint_still_loads_locally(loader_calls, tmp_path):
+    # A checkpoint with one redux subdir was written by mflux-save (or is half-copied);
+    # either way it must not be silently completed from the hub. Routing local lets
+    # WeightLoader name the missing half from disk.
+    (tmp_path / "image_encoder").mkdir()
+    (tmp_path / "image_encoder" / "0.safetensors").touch()
+
+    FluxInitializer._load_redux_weights(model_path=str(tmp_path))
+
+    assert loader_calls["load"]["model_path"] == str(tmp_path)
+
+
+@pytest.mark.fast
+def test_a_builtin_name_downloads_the_redux_encoders(loader_calls):
+    FluxInitializer._load_redux_weights(model_path=None)
+
+    assert loader_calls["load"]["model_path"] == ModelConfig.dev_redux().model_name
+
+
+@pytest.mark.fast
+def test_a_local_path_without_redux_encoders_falls_back_to_the_hub(loader_calls, tmp_path):
+    # A base-only checkpoint (vae/transformer/text encoders, e.g. from `--model dev`) has
+    # no redux subdirs; the encoders still have to come from somewhere, so the hub path stays.
+    (tmp_path / "transformer").mkdir()
+
+    FluxInitializer._load_redux_weights(model_path=str(tmp_path))
+
+    assert loader_calls["load"]["model_path"] == ModelConfig.dev_redux().model_name
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    ("model_config", "model_path", "expected_base_path"),
+    [
+        # The adapter repo ships no base weights, so dev-redux falls back to its base.
+        (ModelConfig.dev_redux(), None, ModelConfig.dev().model_name),
+        # Other configs keep their own model_name.
+        (ModelConfig.dev(), None, ModelConfig.dev().model_name),
+        # An explicit model path always wins, even for the dev-redux config.
+        (ModelConfig.dev_redux(), "/models/dev-redux-8bit", "/models/dev-redux-8bit"),
+    ],
+)
+def test_redux_base_weights_come_from_a_repo_that_has_them(monkeypatch, model_config, model_path, expected_base_path):
+    seen = {}
+
+    def record_init(model, model_config, quantize, model_path=None, **kwargs):
+        seen["model_path"] = model_path
+
+    monkeypatch.setattr(FluxInitializer, "init", record_init)
+    monkeypatch.setattr(FluxInitializer, "_load_redux_weights", lambda model_path: None)
+    monkeypatch.setattr(WeightApplier, "apply_and_quantize", lambda **kwargs: None)
+
+    class ModelStub:
+        pass
+
+    FluxInitializer.init_redux(model=ModelStub(), model_config=model_config, quantize=None, model_path=model_path)
+
+    assert seen["model_path"] == expected_base_path


### PR DESCRIPTION
## What

Fixes #667 — cc @ianscrivener (issue author) @plz12345 (comment thread), and refs the model list from https://github.com/orgs/mflux-community/discussions/677#discussioncomment-18155966.

The `AttributeError: '...' object has no attribute 'save_model'` had two distinct roots, both addressed:

1. **Python API**: every Flux generation variant except `Flux1`/`Flux1Controlnet` — `Flux1Depth`, `Flux1Fill`, `Flux1Kontext`, `Flux1InContextFill` (CatVTON backing), `Flux1InContextDev`, `Flux1Redux` — had no `save_model`. They now delegate to `ModelSaver` with the base `FluxWeightDefinition` (`DepthPro` deliberately stays out of the depth checkpoint: it is a runtime preprocessor, not part of FLUX.1-Depth-dev, which also answers the depth-pro question from the thread: no conversion needed, same as SeedVR2).
2. **`dev-redux` was not saveable at all**: `mflux-save` dispatched it to plain `Flux1`, whose base-weight download patterns can't resolve against `black-forest-labs/FLUX.1-Redux-dev` (that repo ships only `image_encoder/` + `image_embedder/`). While tracing this, a second latent bug surfaced: `mflux-generate-redux` with default args (or `--model dev-redux`) crashed with `FileNotFoundError .../FLUX.1-Redux-dev/vae`, because `init_redux` treated the dev-redux config's `model_name` as a base-weights location even though the repo has no vae/transformer/text encoders.

Changes:

- `Flux1Redux.save_model` writes a self-contained checkpoint (base FLUX.1 components + siglip image encoder + redux embedder) via a new composed `FluxReduxSaveDefinition`; `mflux-save` dispatches `dev-redux` to `Flux1Redux`.
- `init_redux` resolves base weights from `FLUX.1-dev` when handed the dev-redux config (explicit `model_path` always wins), and a new `_load_redux_weights` helper mirrors the #642 controlnet routing: a checkpoint carrying `image_encoder/`/`image_embedder/` loads its encoders from disk (offline use, quantized saves no longer silently swapped for the hub's), base-only checkpoints keep the hub path, half-saved ones fail loudly instead of mixing sources.
- README: Redux section documents `mflux-save --model dev-redux` and checkpoint reload.

Already-fine parts of the issue list (no code needed): the ControlNets and `z-image-turbo-controlnet-union-2.1` save correctly since the 0.19.0 registry dispatch rework (#607); `lens-turbo`/`seedvr2-*` are explicit parse-time rejects rather than opaque tracebacks. Deliberate deferrals: **Lens** stays unsaveable (its transformer is a single-file `mlx_native` checkpoint — the same save-machinery class as the frozen #621, follow-up); **Qwen-Image-Layered** isn't an mflux model (new port / feature request).

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default (selector: `-m "not slow and not high_memory_requirement"`, same as `just test`). Only mark `@pytest.mark.slow` or `@pytest.mark.high_memory_requirement` when a test exceeds CI's time or memory budget (typically weight downloads / image generation).
- [x] `ruff check` and `ruff format` are clean (`uv run ruff` uses the version pinned in the dev dependencies of `pyproject.toml`, which is the single source of truth for pre-commit and CI; `pre-commit run -a` covers it locally).
- [x] `CHANGELOG.md`: entry under `Unreleased` referencing this PR number.
- [x] Docs updated where behavior changed — README examples/table rows are part of the API contract (see `.cursor/rules/RULE.md`).
- [ ] New model: shared config wiring (aliases, default steps, mflux-save dispatch, capabilities, completions), thin CLI entrypoint, and `src/mflux/models/<name>/README.md`. — N/A
- [ ] New/changed CLI: ignored/rejected options declared (`IGNORED_OPTIONS`/`REJECTED_OPTIONS`) and `warn_ignored_options` actually called in `main()` — `mflux-capabilities` must stay truthful. — N/A (no option surface changes)

## Verification

- `just test-fast` → **1327 passed, 3 skipped** (includes new coverage below); `just lint` → clean; commit hooks (ruff, typos, ty) pass.
- `tests/weights/test_flux_redux_local_load.py` (new): pins `_load_redux_weights` routing (saved checkpoint → local, hub builtin → hub, base-only dir → hub, half-saved → local) and pins the base-weights location for the dev-redux config (falls back to `FLUX.1-dev`; explicit path wins).
- `tests/model_saving/test_tiny_model_saving_flux_redux.py` (new): tiny real roundtrip of the siglip encoder + redux embedder through `ModelSaver` → `WeightLoader` → `WeightApplier`, exercising the `weight_subkey` fallback and `bulk_transform` non-reapplication on mflux-format reload.
- `tests/model_saving/test_save_cli_dispatch.py`: explicit `dev-redux → Flux1Redux` dispatch row + presence test pinning `save_model` on all six variant classes (the #667 regression class).
- Real CLI smoke: `mflux-generate-redux --prompt ... --redux-image-paths ...` on the default arguments gets past weight loading into `generate_image` (previously crashed in `WeightLoader` resolving the base against the Redux repo).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All FLUX variants can now save model checkpoints.
  * FLUX.1 Redux checkpoints are self-contained, including required image encoders and supporting components.
  * Saved Redux checkpoints can be reloaded with their locally stored components.
  * Added support for quantized Redux checkpoint saving and multi-shard output.

* **Bug Fixes**
  * Redux generation now selects appropriate base model weights and avoids unnecessary adapter-loading failures.

* **Documentation**
  * Added instructions for saving and loading self-contained, quantized FLUX.1 Redux checkpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds `save_model` support across FLUX generation variants and makes Redux saves self-contained by combining base FLUX components with the image encoder and embedder. It also routes local Redux components during reload and fixes default Redux base-weight resolution.

- Dispatches `dev-redux` saves through `Flux1Redux`.
- Adds composed Redux save definitions and local-versus-hub Redux loading.
- Adds save methods for depth, fill, Kontext, and in-context variants.
- Adds Redux routing, dispatch, and tiny checkpoint round-trip tests.

<h3>Confidence Score: 4/5</h3>

The quantization metadata mismatch should be fixed before merging because a supported Python save path can write dense Redux components while identifying them as quantized.

Base and Redux precision are resolved separately, but the composed saver records only the base result across every component, making some self-contained Redux checkpoints misrepresent their actual precision.

**Files Needing Attention:** src/mflux/models/flux/flux_initializer.py, src/mflux/models/flux/variants/redux/flux_redux.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mflux/models/flux/flux_initializer.py | Fixes Redux base and local-component routing, but discards the independently resolved Redux quantization level used by the new save path. |
| src/mflux/models/flux/weights/flux_weight_definition.py | Adds a composed definition that saves the base FLUX and Redux component sets together. |
| src/mflux/models/flux/variants/redux/flux_redux.py | Adds self-contained Redux checkpoint saving through FluxReduxSaveDefinition. |
| src/mflux/models/common/cli/save.py | Correctly dispatches the dev-redux registry entry to Flux1Redux. |
| tests/weights/test_flux_redux_local_load.py | Covers local Redux routing and base-weight source selection but not divergent base and Redux quantization states. |
| tests/model_saving/test_tiny_model_saving_flux_redux.py | Exercises Redux component round-tripping at one uniform requested precision. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Redux model selection] --> B[Load base FLUX weights]
  A --> C[Load Redux image components]
  B --> D[Apply base quantization]
  C --> E[Apply Redux quantization]
  D --> F[FluxReduxSaveDefinition]
  E --> F
  F --> G[Self-contained checkpoint]
  G --> H[Reload base components locally]
  G --> I[Reload Redux components locally]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/mflux/models/flux/flux_initializer.py`, line 99-107 ([link](https://github.com/mflux-community/mflux/blob/5b4f4a7bd120280e0ea2e0be4c9bda5f5d6d4a3d/src/mflux/models/flux/flux_initializer.py#L99-L107)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Redux quantization metadata diverges**

   When a pre-quantized base-only checkpoint is loaded without an explicit quantization argument, the base retains its stored precision while the Redux components load densely, but `save_model` labels every component with the base-only `self.bits` value. This produces a checkpoint whose `image_encoder` and `image_embedder` metadata falsely identifies dense weights as quantized and does not provide the documented quantized-together Redux save.

   **Context Used:** MLX (Apple Silicon) codebase. Prioritize mx.array ... ([source](https://github.com/mflux-community/mflux/blob/5b4f4a7bd120280e0ea2e0be4c9bda5f5d6d4a3d/greptile.json))
   
   **Knowledge Base Used:**
   - [Model loading and adaptation](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/model-loading-and-adaptation.md)
   - [FLUX generation](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/flux-generation.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/mflux/models/flux/flux_initializer.py
   Line: 99-107
   
   Comment:
   **Redux quantization metadata diverges**
   
   When a pre-quantized base-only checkpoint is loaded without an explicit quantization argument, the base retains its stored precision while the Redux components load densely, but `save_model` labels every component with the base-only `self.bits` value. This produces a checkpoint whose `image_encoder` and `image_embedder` metadata falsely identifies dense weights as quantized and does not provide the documented quantized-together Redux save.
   
   **Context Used:** MLX (Apple Silicon) codebase. Prioritize mx.array ... ([source](https://github.com/mflux-community/mflux/blob/5b4f4a7bd120280e0ea2e0be4c9bda5f5d6d4a3d/greptile.json))
   
   **Knowledge Base Used:**
   - [Model loading and adaptation](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/model-loading-and-adaptation.md)
   - [FLUX generation](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/flux-generation.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/mflux/models/flux/flux_initializer.py:99-107
**Redux quantization metadata diverges**

When a pre-quantized base-only checkpoint is loaded without an explicit quantization argument, the base retains its stored precision while the Redux components load densely, but `save_model` labels every component with the base-only `self.bits` value. This produces a checkpoint whose `image_encoder` and `image_embedder` metadata falsely identifies dense weights as quantized and does not provide the documented quantized-together Redux save.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/issue-667"](https://github.com/mflux-community/mflux/commit/5b4f4a7bd120280e0ea2e0be4c9bda5f5d6d4a3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57300964)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Context used - MLX (Apple Silicon) codebase. Prioritize mx.array ... ([source](https://github.com/mflux-community/mflux/blob/5b4f4a7bd120280e0ea2e0be4c9bda5f5d6d4a3d/greptile.json))
- Knowledge Base — [FLUX model family](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/flux-model-family.md)
- Knowledge Base — [FLUX generation](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/flux-generation.md)
- Knowledge Base — [Model loading and adaptation](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/model-loading-and-adaptation.md)
</details>


<!-- /greptile_comment -->