### PR TITLE
ensure current directory is a git repo in `just install`

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,6 +8,16 @@ venv_dir := ".venv"
 ruff_version := `sed -n 's/^    "ruff==\([0-9.]*\)",$/\1/p' pyproject.toml`
 
 # Show all recipes
+default:# justfile for mflux Python 3.10+ project, using 3.13 as recommended maintainer Python as of Jan 2026
+
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+python_version := "3.13"
+venv_dir := ".venv"
+# Ruff version derives from the pinned dev dependency in pyproject.toml (single source of truth)
+ruff_version := `sed -n 's/^    "ruff==\([0-9.]*\)",$/\1/p' pyproject.toml`
+
+# Show all recipes
 default:
     @just --list
 
@@ -16,6 +26,31 @@ all: install test
 
 # Create the virtual environment, install dependencies and pre-commit hooks
 install: venv-init ensure-pre-commit
+    @echo "🏗️ Checking current direcctory is a git repo..."    
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      @echo "✅ Directory is a Git repository"
+    else
+      git init
+      @echo "✅ ran git init"
+    fi    
+
+    @echo "🏗️ Installing dependencies and pre-commit hooks..."
+    uv sync --python {{ python_version }}
+    @echo "✅ Dependencies installed."
+    @just --list
+
+# Set up the project and run the default tests
+all: install test
+
+# Create the virtual environment, install dependencies and pre-commit hooks
+install: venv-init ensure-pre-commit
+    @echo "🏗️ Checking current direcctory is a git repo..."    
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      echo "Inside a Git repository"
+    else
+      echo "Not a Git repository"
+    fi    
+
     @echo "🏗️ Installing dependencies and pre-commit hooks..."
     uv sync --python {{ python_version }}
     @echo "✅ Dependencies installed."


### PR DESCRIPTION
`just install` throws an error if curerent directory is not a git repo

add `git init` if required

## What

<!-- One short paragraph: what changes and why. Link issues: Fixes #... -->

## Checklist (definition of done)

- [ ] Tests added/updated run in CI by default (selector: `-m "not slow and not high_memory_requirement"`, same as `just test`). Only mark `@pytest.mark.slow` or `@pytest.mark.high_memory_requirement` when a test exceeds CI's time or memory budget (typically weight downloads / image generation).
- [ ] `ruff check` and `ruff format` are clean (`uv run ruff` uses the version pinned in the dev dependencies of `pyproject.toml`, which is the single source of truth for pre-commit and CI; `pre-commit run -a` covers it locally).
- [ ] `CHANGELOG.md`: entry under `Unreleased` referencing this PR number.
- [ ] Docs updated where behavior changed — README examples/table rows are part of the API contract (see `.cursor/rules/RULE.md`).
- [ ] New model: shared config wiring (aliases, default steps, mflux-save dispatch, capabilities, completions), thin CLI entrypoint, and `src/mflux/models/<name>/README.md`.
- [ ] New/changed CLI: ignored/rejected options declared (`IGNORED_OPTIONS`/`REJECTED_OPTIONS`) and `warn_ignored_options` actually called in `main()` — `mflux-capabilities` must stay truthful.

## Verification

<!-- Commands you ran and what you observed. Include generated images/screenshots for model-affecting changes. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The installation workflow now initializes a Git repository when needed.
  * Added automatic Python environment synchronization during installation.
  * Installation now displays clearer progress messages and available commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR attempts to make `just install` initialize a Git repository when necessary.
- Adds a Git work-tree check and conditional `git init`.
- Accidentally duplicates top-level configuration and core recipes.
- Expresses the new shell conditional across independently executed recipe lines.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge because the justfile cannot be parsed, and the new Git check would still abort as an incomplete shell conditional after the duplicates are corrected.

Duplicate top-level declarations prevent every recipe from loading, while the Git initialization block spans independent shell invocations and therefore cannot execute as a valid compound command.

**Files Needing Attention:** justfile

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| justfile | Adds repository initialization, but duplicate definitions prevent parsing and the multiline conditional cannot execute as written. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
justfile:10
**Duplicate definitions block parsing**

When any `just` command parses this file, the duplicated variables and `default`, `all`, and `install` recipes violate Just's default uniqueness requirements, causing the justfile to fail to load before any recipe can run.

### Issue 2
justfile:30
**Conditional spans shell invocations**

When `just install` reaches this check after the duplicate definitions are removed, Just executes the non-shebang recipe lines independently, so Bash receives an incomplete `if` statement and aborts before checking or initializing the repository.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ensure current directory is a git repo i..."](https://github.com/mflux-community/mflux/commit/d6b694900871ee772ec79123230833be1c8ecbb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57298718)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->