### PR TITLE
`just install` ensure current directory is a git repo

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,6 +16,13 @@ all: install test
 
 # Create the virtual environment, install dependencies and pre-commit hooks
 install: venv-init ensure-pre-commit
+    @echo "🏗️ Checking current direcctory is a git repo..."    
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      @echo "✅ Directory is a Git repository"
+    else
+      git init
+      @echo "✅ ran git init"
+    fi    
     @echo "🏗️ Installing dependencies and pre-commit hooks..."
     uv sync --python {{ python_version }}
     @echo "✅ Dependencies installed."

--- a/justfile
+++ b/justfile
@@ -17,12 +17,12 @@ all: install test
 # Create the virtual environment, install dependencies and pre-commit hooks
 install: venv-init ensure-pre-commit
     @echo "🏗️ Checking current direcctory is a git repo..."    
-    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-      @echo "✅ Directory is a Git repository"
-    else
-      git init
-      @echo "✅ ran git init"
-    fi    
+    @if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+      echo "✅ Directory is a Git repository"; \
+    else \
+      git init; \
+      echo "✅ ran git init"; \
+    fi
     @echo "🏗️ Installing dependencies and pre-commit hooks..."
     uv sync --python {{ python_version }}
     @echo "✅ Dependencies installed."


### PR DESCRIPTION
`just install` assumes that the current directly is a Git repository - an throws an error if not.

## What

<!-- One short paragraph: what changes and why. Link issues: Fixes #... -->

## Checklist (definition of done)

- [ ] Tests added/updated run in CI by default (selector: `-m "not slow and not high_memory_requirement"`, same as `just test`). Only mark `@pytest.mark.slow` or `@pytest.mark.high_memory_requirement` when a test exceeds CI's time or memory budget (typically weight downloads / image generation).
- [ ] `ruff check` and `ruff format` are clean (`uv run ruff` uses the version pinned in the dev dependencies of `pyproject.toml`, which is the single source of truth for pre-commit and CI; `pre-commit run -a` covers it locally).
- [ ] `CHANGELOG.md`: entry under `Unreleased` referencing this PR number.
- [ ] Docs updated where behavior changed — README examples/table rows are part of the API contract (see `.cursor/rules/RULE.md`).
- [ ] New model: shared config wiring (aliases, default steps, mflux-save dispatch, capabilities, completions), thin CLI entrypoint, and `src/mflux/models/<name>/README.md`.
- [ ] New/changed CLI: ignored/rejected options declared (`IGNORED_OPTIONS`/`REJECTED_OPTIONS`) and `warn_ignored_options` actually called in `main()` — `mflux-capabilities` must stay truthful.

## Verification

<!-- Commands you ran and what you observed. Include generated images/screenshots for model-affecting changes. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installation now detects whether it is running inside a Git repository.
  * Automatically initializes a Git repository when one is not present.
  * Provides confirmation when an existing repository is detected.
  * Installation continues automatically after repository setup, giving users a smoother first-time setup experience without requiring manual Git initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates `just install` to initialize Git when invoked outside an existing work tree.
- Adds a Git work-tree check before dependency installation.
- Runs `git init` when the check fails.

<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge until the new conditional is executed as one shell command so `just install` can complete.

The first line of the newly added conditional is executed independently and is therefore an unterminated Bash `if`, preventing dependency and pre-commit installation.

**Files Needing Attention:** justfile

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| justfile | Adds repository initialization to `install`, but the unjoined multiline conditional makes the recipe fail immediately. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
justfile:20-25
**Conditional Runs Separately**

When `just install` or `just all` runs, Just executes the unjoined `if` line as a separate shell command, causing an unterminated Bash conditional that aborts before dependencies and pre-commit hooks are installed.

```suggestion
    @if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
      echo "✅ Directory is a Git repository"; \
    else \
      git init; \
      echo "✅ ran git init"; \
    fi
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["\`just install\` ensure current directory ..."](https://github.com/mflux-community/mflux/commit/029fef32e898bf84e91e900f88e578a39484557f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57305208)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->