### PR TITLE
perf: per-phase generation benchmark harness with A/B plotting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ tests/training/tmp/
 # build/ generated from 'pip install -e .' in developer mode
 build/
 
+# benchmark artifacts (`just benchmark` / `just benchmark-plot`)
+bench_*.json
+benchmark.png
+
 # regenerable cache output, e.g. `just ci-extract`
 .ci_cache/
 .gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Improvements
 
+- **Per-phase generation benchmark harness with A/B plotting**: `scripts/benchmark.py` times encode/denoise/decode and peak MLX memory per run for the 8 txt2img families in scope for the `mx.compile` coverage rollout, emitting a JSON report that embeds chip, OS, MLX version, git SHA + dirty flag so before/after runs stay comparable; `scripts/benchmark_plot.py` renders reports as a comparison PNG (stacked per-phase bars, per-step denoise lines) plus a per-model delta table. `just benchmark` / `just benchmark-plot` wrap both; matplotlib (already a main dependency) is the only plotting requirement. Reports default to stable short-run statistics since sustained sessions can thermal-throttle ~1.7×. (#685)
 - **Training loss monitoring no longer taxes the run**: the loop computed a loss every step and discarded it, then paid up to 10 extra forward passes per plot tick for a smoothed re-read of training samples; with `plot_frequency: 1` that tripled wall time (5.4 vs 17.5 s/step on a Krea 2 Raw QLoRA, the 80 vs 232 hour run of #671). The already-computed value now feeds the loss curve every step for free, the batch metric became an optional second series at `plot_frequency` ticks, and `plot_frequency` is optional with a default of 20. Checkpoint loss statistics carry both series; a legacy checkpoint's single series loads as the batch metric it was. (#671, #672)
 
 ## [0.19.1] - 2026-08-20

--- a/JUSTFILE.md
+++ b/JUSTFILE.md
@@ -46,6 +46,8 @@ a uv tool.
 | `just test-slow` | Run tests marked `slow`; these generate images. |
 | `just test-all` | Run all tests except those marked `high_memory_requirement`. This can download model weights. |
 | `just build` | Build sdist/wheel into `dist/`, then report artifact sizes and flag any oversized files in the sdist (a check that image assets weren't accidentally bundled). |
+| `just benchmark [model] [quantize] [runs] [size]` | Run the per-phase generation benchmark (`scripts/benchmark.py`; encode/denoise/decode timings + peak GB) and write a JSON report whose filename embeds the git SHA + dirty flag so A/B runs never overwrite each other. Defaults: `z-image-turbo 8 2 1024`. |
+| `just benchmark-plot before.json [after.json ...]` | Render one or more benchmark JSON reports into `benchmark.png` (stacked per-phase bars + per-step times) and print a delta table; the first report is the A/B baseline. |
 | `just release` | Trigger the `release.yml` GitHub Actions workflow via `gh`, then watch the run. Publishing happens on GitHub via PyPI trusted publishing (OIDC); no local credentials are used. |
 | `just clean` | Remove `.venv`. Run `just install` to recreate it. |
 
@@ -57,6 +59,83 @@ available for inspection. They do not update golden images.
 wheel packages with `uv build`, then reports their sizes (expected under 1MB)
 and lists the five largest files inside the sdist — a quick sanity check that
 no image outputs got swept into the package by mistake.
+
+## Benchmarking
+
+`just benchmark` measures where generation time goes — text encode, denoise
+loop, and VAE decode, plus peak MLX memory — and writes a JSON report whose
+filename embeds the git SHA + dirty flag, so A/B runs never overwrite each
+other:
+
+```sh
+just benchmark                          # defaults: z-image-turbo q8, 2 runs, 1024px
+just benchmark qwen-image none 3 768    # model, quantize (or 'none'), runs, square size
+```
+
+Example output:
+
+```text
+$ just benchmark
+🏗️ Benchmarking z-image-turbo (quantize=8, runs=2, 1024px) → bench_z-image-turbo_q8_1024px_0f927481-dirty.json ...
+=== z-image-turbo (quantize=8, 2 run(s)) ===
+100%|██████████████████████████████████| 9/9 [01:07<00:00, 7.54s/it]
+  run 0: encode 0.01s | denoise 67.92s | decode 0.64s | total 68.58s | peak 36.0 GB
+100%|██████████████████████████████████| 9/9 [01:34<00:00, 10.50s/it]
+  run 1: encode 0.00s | denoise 94.71s | decode 0.98s | total 95.70s | peak 36.0 GB
+
+=== summary (median of runs; run 0 includes compile warmup) ===
+  z-image-turbo: total min 68.58s / median 82.14s, denoise median 81.32s over 2 run(s)
+
+wrote bench_z-image-turbo_q8_1024px_0f927481-dirty.json
+✅ Benchmark written to bench_z-image-turbo_q8_1024px_0f927481-dirty.json.
+```
+
+This example also shows why one long session can mislead: run 1 came in ~40%
+slower than run 0 on identical work because sustained GPU load thermal-throttles
+the machine. Prefer several short runs and compare **min / median**, which is
+exactly what `summary` prints.
+
+### When to benchmark
+
+- **Before and after any performance change** (`mx.compile` coverage,
+  CFG batching, async eval). The report filename embeds the git SHA + dirty
+  flag, so one command per side of the change is enough to keep both results:
+  ```sh
+  git checkout main              # on the baseline...
+  just benchmark                 # → bench_..._abc1234-clean.json
+  # ...make your change, then
+  just benchmark                 # → bench_..._def5678-dirty.json
+  just benchmark-plot bench_..._abc1234-clean.json bench_..._def5678-dirty.json
+  ```
+- Keep every variable fixed except your code change: same model, quantize,
+  size, steps, seed, prompt, and machine state (plugged in, cooled down).
+- The first run in a report includes MLX compile warmup on compiled models;
+  that latency is itself a metric, so it is reported rather than hidden.
+
+Plotting a single report works too and is a quick sanity check after a run:
+
+```text
+$ just benchmark-plot bench_z-image-turbo_q8_1024px_0f927481-dirty.json
+🏗️ Plotting benchmark report(s) → benchmark.png ...
+wrote benchmark.png
+✅ Chart written to benchmark.png.
+```
+
+With two or more reports (baseline **first**), the same command adds a
+per-model delta table with percent changes to the stdout above the chart:
+
+```sh
+just benchmark-plot bench_<model>_q8_1024px_abc1234-clean.json bench_<model>_q8_1024px_def5678-dirty.json
+```
+
+Either way `benchmark.png` shows stacked per-phase bars (one group per model,
+hatch pattern per report) plus per-step denoise times. The file lands in the
+repo root (`*.png` is gitignored, so charts never dirty your worktree); open
+it with
+
+```sh
+open benchmark.png        # macOS; Linux: xdg-open benchmark.png
+```
 
 ## Releasing to PyPI
 

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ all: install test
 
 # Create the virtual environment, install dependencies and pre-commit hooks
 install: venv-init ensure-pre-commit
-    @echo "🏗️ Checking current direcctory is a git repo..."    
+    @echo "🏗️ Checking current directory is a git repo..."    
     @if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
       echo "✅ Directory is a Git repository"; \
     else \
@@ -121,6 +121,71 @@ ci-extract:
     @echo "🏗️ Extracting model registry..."
     uv run --no-sync python scripts/ci_extract_models.py
     @echo "✅ Extraction complete."
+
+# Run the per-phase generation benchmark (encode/denoise/decode + peak GB) → JSON report.
+# Output file embeds git SHA + dirty flag so A/B runs never overwrite each other.
+# Usage: just benchmark [model=z-image-turbo] [quantize=8|none] [runs=2] [size=1024]
+benchmark model="z-image-turbo" quantize="8" runs="2" size="1024":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    model="{{ model }}"
+    quantize="{{ quantize }}"
+    size="{{ size }}"
+    runs="{{ runs }}"
+    sha="$(git rev-parse --short HEAD)-$(git diff --quiet && echo clean || echo dirty)"
+    out="bench_${model}_q${quantize}_${size}px_${sha}.json"
+    args=(--model "$model" --runs "$runs" --width "$size" --height "$size" --json-out "$out")
+    if [[ "$quantize" != "none" ]]; then args+=(-q "$quantize"); fi
+    echo "🏗️ Benchmarking $model (quantize=$quantize, runs=$runs, ${size}px) → $out ..."
+    uv run --no-sync python scripts/benchmark.py "${args[@]}"
+    echo "✅ Benchmark written to $out."
+
+# Plot one or more benchmark JSON reports as a comparison PNG (+ delta table for 2+).
+# First report is the A/B baseline. For a custom output path, call
+# scripts/benchmark_plot.py directly.
+# Usage: just benchmark-plot before.json [after.json ...]
+benchmark-plot *reports:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    reports="{{ reports }}"
+    if [ -z "$reports" ]; then
+        echo "❌ benchmark-plot needs at least one benchmark JSON report to plot." >&2
+        echo "" >&2
+        echo "   1️⃣  Generate a report first:   just benchmark" >&2
+        echo "   2️⃣  Then plot it, e.g.:         just benchmark-plot bench_z-image-turbo_q8_1024px_<sha>.json" >&2
+        echo "" >&2
+        echo "   Pass two or more reports (baseline first) to get an A/B chart + delta table," >&2
+        echo "   e.g. before/after a code change: 'just benchmark-plot bench_*_abc1234-clean.json bench_*_def5678-dirty.json'" >&2
+        echo "" >&2
+        echo "   Tip: 'just benchmark' names its output so A/B runs never overwrite each other;" >&2
+        echo "   any bench_*.json in this directory can be plotted." >&2
+        if compgen -G "bench_*.json" > /dev/null; then
+            echo "" >&2
+            echo "   Reports found here:" >&2
+            ls -1t bench_*.json | sed 's/^/     • /' >&2
+        fi
+        exit 1
+    fi
+    missing=""
+    for f in $reports; do
+        [ -f "$f" ] || missing="$missing $f"
+    done
+    if [ -n "$missing" ]; then
+        echo "❌ These report files do not exist:$missing" >&2
+        echo "   Run 'just benchmark' to produce one, or check the path/spelling." >&2
+        if compgen -G "bench_*.json" > /dev/null; then
+            echo "" >&2
+            echo "   Reports found here:" >&2
+            ls -1t bench_*.json | sed 's/^/     • /' >&2
+        fi
+        exit 1
+    fi
+    echo "🏗️ Plotting benchmark report(s) → benchmark.png ..."
+    # Paths are unquoted by necessity (just bakes them into the script verbatim);
+    # quote-free repo-relative names keep this safe.
+    # shellcheck disable=SC2086
+    uv run --no-sync python scripts/benchmark_plot.py $reports --out benchmark.png
+    echo "✅ Chart written to benchmark.png."
 
 # Remove the virtual environment
 clean:

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,286 @@
+# Per-phase generation benchmark: encode / denoise / decode wall times + peak MLX
+# memory, emitted as JSON. This harness exists so the mx.compile coverage rollout
+# (plan/next-improvements-proposal.md, improvement #1) can be done methodically:
+# one fixed-seed A/B command per model, before and after each compile change.
+#
+#   uv run python scripts/benchmark.py --model z-image-turbo -q 8
+#   uv run python scripts/benchmark.py --model qwen-image --steps 20 --runs 3 --json-out qwen_before.json
+#
+# Timing note: MLX submits work asynchronously, so `encode_s` includes any
+# submission slop absorbed by the loop's first step; the per-step mx.eval in every
+# denoise loop makes `denoise_s` (and `total_s`, which ends in a full host
+# materialization) hard numbers. For A/B comparisons of the same model the encode
+# bias is constant, which is all the compile work needs. Individual `step_times_s`
+# are shifted by one sync (in_loop fires just before that step's mx.eval), so read
+# them as diagnostics, not absolute per-step costs.
+#
+# Sustained-load caveat: long runs can thermal-throttle (observed: 9-step q8 run 1
+# at ~1.7x run 0 step time on M4 Max; 4-step runs are stable to ±1.3%). For A/B
+# decisions prefer min/median of several short runs over one long session.
+import argparse
+import importlib.metadata
+import json
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import mlx.core as mx
+import PIL.Image
+import tqdm
+
+from mflux.callbacks.callback import AfterLoopCallback, BeforeLoopCallback, InLoopCallback
+from mflux.callbacks.instances.memory_saver import MemorySaver
+from mflux.cli.defaults.defaults import model_inference_steps
+from mflux.models.boogu.variants.txt2img.boogu_image import BooguImage
+from mflux.models.common.config.config import Config
+from mflux.models.common.config.model_config import ModelConfig
+from mflux.models.fibo.variants.txt2img.fibo import FIBO
+from mflux.models.flux.variants.txt2img.flux import Flux1
+from mflux.models.krea2.variants.txt2img.krea2 import Krea2
+from mflux.models.lens.variants.txt2img.lens_image import LensImage
+from mflux.models.qwen.variants.txt2img.qwen_image import QwenImage
+from mflux.models.z_image.variants.z_image import ZImage
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    cls: type
+    config: ModelConfig
+
+
+# Keyed by canonical AVAILABLE_MODELS names so model_inference_steps() resolves the
+# same step defaults the CLIs use. Registry covers the txt2img families in scope for
+# the compile-coverage work; adding a row is the whole cost of covering a new one.
+MODEL_SPECS: dict[str, ModelSpec] = {
+    "z-image-turbo": ModelSpec(cls=ZImage, config=ModelConfig.z_image_turbo()),
+    "qwen-image": ModelSpec(cls=QwenImage, config=ModelConfig.qwen_image()),
+    "krea-2": ModelSpec(cls=Krea2, config=ModelConfig.krea2()),
+    "boogu-image-turbo": ModelSpec(cls=BooguImage, config=ModelConfig.boogu_image_turbo()),
+    "fibo": ModelSpec(cls=FIBO, config=ModelConfig.fibo()),
+    "lens-turbo": ModelSpec(cls=LensImage, config=ModelConfig.lens_turbo()),
+    "dev": ModelSpec(cls=Flux1, config=ModelConfig.dev()),
+    "schnell": ModelSpec(cls=Flux1, config=ModelConfig.schnell()),
+}
+
+
+class BenchmarkTimer(BeforeLoopCallback, InLoopCallback, AfterLoopCallback):
+    def __init__(self, clock=time.perf_counter):
+        self.clock = clock
+        self.t_start = None
+        self.t_loop_start = None
+        self.t_loop_end = None
+        self.step_stamps = []
+
+    def mark_start(self) -> None:
+        self.t_start = self.clock()
+        self.t_loop_start = None
+        self.t_loop_end = None
+        self.step_stamps = []
+
+    def call_before_loop(
+        self,
+        seed: int,
+        prompt: str,
+        latents: mx.array,
+        config: Config,
+        canny_image: PIL.Image.Image | None = None,
+        depth_image: PIL.Image.Image | None = None,
+        control_images: list[PIL.Image.Image] | None = None,
+    ) -> None:
+        self.t_loop_start = self.clock()
+
+    def call_in_loop(
+        self,
+        t: int,
+        seed: int,
+        prompt: str,
+        latents: mx.array,
+        config: Config,
+        time_steps: tqdm.tqdm,
+    ) -> None:
+        self.step_stamps.append(self.clock())
+
+    def call_after_loop(self, seed: int, prompt: str, latents: mx.array, config: Config) -> None:
+        self.t_loop_end = self.clock()
+
+    def result(self, t_end: float, peak_memory_bytes: int) -> dict:
+        step_times = [b - a for a, b in zip([self.t_loop_start, *self.step_stamps], self.step_stamps, strict=False)]
+        return {
+            "encode_s": self.t_loop_start - self.t_start,
+            "denoise_s": self.t_loop_end - self.t_loop_start,
+            "decode_s": t_end - self.t_loop_end,
+            "total_s": t_end - self.t_start,
+            "step_times_s": step_times,
+            "peak_memory_gb": peak_memory_bytes / 1e9,
+        }
+
+
+class Benchmark:
+    @staticmethod
+    def run_model(model_name: str, spec: ModelSpec, args: argparse.Namespace) -> list[dict]:
+        print(f"=== {model_name} (quantize={args.quantize}, {args.runs} run(s)) ===")
+        model = spec.cls(
+            quantize=args.quantize,
+            model_path=args.model_path,
+            model_config=spec.config,
+        )
+        # Mirrors the CLI's non-low-ram path: text encoders stay resident across the
+        # run loop (num_seeds>1), transformer kept, cache cleared between runs.
+        model.callbacks.register(
+            MemorySaver(model=model, keep_transformer=True, cache_limit_bytes=None, num_seeds=args.runs)
+        )
+        # One timer for the whole run loop; mark_start() resets its state per run so
+        # nothing accumulates on the registry.
+        timer = BenchmarkTimer()
+        model.callbacks.register(timer)
+
+        runs = []
+        for run_index in range(args.runs):
+            generate_kwargs = {
+                "seed": args.seed,
+                "prompt": args.prompt,
+                "num_inference_steps": args.steps or model_inference_steps(model_name),
+                "width": args.width,
+                "height": args.height,
+            }
+            if args.guidance is not None:
+                generate_kwargs["guidance"] = args.guidance
+            if args.negative_prompt is not None:
+                generate_kwargs["negative_prompt"] = args.negative_prompt
+
+            mx.reset_peak_memory()
+            timer.mark_start()
+            model.generate_image(**generate_kwargs)
+            result = timer.result(t_end=timer.clock(), peak_memory_bytes=mx.get_peak_memory())
+            result["model"] = model_name
+            result["run_index"] = run_index
+            runs.append(result)
+            Benchmark._print_run(result)
+        return runs
+
+    @staticmethod
+    def summarize(runs: list[dict]) -> list[dict]:
+        summaries = []
+        for model_name in dict.fromkeys(run["model"] for run in runs):
+            totals = [run["total_s"] for run in runs if run["model"] == model_name]
+            denoise = [run["denoise_s"] for run in runs if run["model"] == model_name]
+            summaries.append(
+                {
+                    "model": model_name,
+                    "runs": len(totals),
+                    "total_min_s": min(totals),
+                    "total_median_s": statistics.median(totals),
+                    "denoise_median_s": statistics.median(denoise),
+                }
+            )
+        return summaries
+
+    @staticmethod
+    def system_info() -> dict:
+        chip = ""
+        if platform.system() == "Darwin":
+            try:
+                chip = subprocess.run(
+                    ["sysctl", "-n", "machdep.cpu.brand_string"], capture_output=True, text=True, check=True
+                ).stdout.strip()
+            except (subprocess.CalledProcessError, OSError):
+                pass
+        try:
+            mflux_version = importlib.metadata.version("mflux")
+        except importlib.metadata.PackageNotFoundError:
+            mflux_version = "unknown"
+        return {
+            "chip": chip,
+            "os": platform.platform(),
+            "python": platform.python_version(),
+            "mlx": mx.__version__,
+            "mflux": mflux_version,
+        }
+
+    @staticmethod
+    def git_info() -> dict:
+        def git(*args: str) -> str:
+            return subprocess.run(["git", *args], capture_output=True, text=True).stdout.strip()
+
+        return {
+            "commit": git("rev-parse", "--short", "HEAD"),
+            "dirty": bool(git("status", "--porcelain")),
+        }
+
+    @staticmethod
+    def _print_run(run: dict) -> None:
+        print(
+            f"  run {run['run_index']}: "
+            f"encode {run['encode_s']:.2f}s | denoise {run['denoise_s']:.2f}s | "
+            f"decode {run['decode_s']:.2f}s | total {run['total_s']:.2f}s | "
+            f"peak {run['peak_memory_gb']:.1f} GB"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Per-phase mflux generation benchmark (JSON out).")
+    parser.add_argument(
+        "--model",
+        action="append",
+        choices=list(MODEL_SPECS),
+        help="Model to benchmark (repeatable). Default: z-image-turbo",
+    )
+    parser.add_argument("--prompt", default="A puffin standing on a cliff")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--steps", type=int, default=None, help="Default: the model's CLI step count")
+    parser.add_argument("--width", type=int, default=1024)
+    parser.add_argument("--height", type=int, default=1024)
+    parser.add_argument("--guidance", type=float, default=None, help="Default: the model's own default")
+    parser.add_argument("--negative-prompt", default=None)
+    parser.add_argument("--quantize", "-q", type=int, choices=[3, 4, 5, 6, 8], default=None)
+    parser.add_argument("--model-path", default=None)
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=2,
+        help="Generations per model. Run 0 includes MLX compile warmup on compiled models — "
+        "kept in the report because compile latency is itself a metric for the compile-coverage work.",
+    )
+    parser.add_argument("--json-out", default="benchmark_results.json")
+    args = parser.parse_args()
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "system": Benchmark.system_info(),
+        "git": Benchmark.git_info(),
+        "config": {
+            "prompt": args.prompt,
+            "seed": args.seed,
+            "steps": args.steps,
+            "width": args.width,
+            "height": args.height,
+            "guidance": args.guidance,
+            "quantize": args.quantize,
+        },
+        "runs": [],
+    }
+    for model_name in args.model or ["z-image-turbo"]:
+        report["runs"].extend(Benchmark.run_model(model_name, MODEL_SPECS[model_name], args))
+
+    report["summary"] = Benchmark.summarize(report["runs"])
+    print("\n=== summary (median of runs; run 0 includes compile warmup) ===")
+    for row in report["summary"]:
+        print(
+            f"  {row['model']}: total min {row['total_min_s']:.2f}s / median {row['total_median_s']:.2f}s, "
+            f"denoise median {row['denoise_median_s']:.2f}s over {row['runs']} run(s)"
+        )
+
+    out = Path(args.json_out)
+    out.write_text(json.dumps(report, indent=2) + "\n")
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark_plot.py
+++ b/scripts/benchmark_plot.py
@@ -1,0 +1,215 @@
+# Render benchmark JSON reports (scripts/benchmark.py) as a comparison chart:
+# stacked per-phase bars for each model's best run + per-step denoise times, one
+# group per input file — the before/after view for the mx.compile coverage work.
+#
+#   uv run python scripts/benchmark_plot.py qwen_before.json qwen_after.json --out qwen.png
+#
+# Also prints a per-model delta table when given 2+ files. matplotlib is a main
+# dependency (training loss plots), so no new requirements; Agg backend keeps it
+# headless. *.png is gitignored, so chart files never dirty the repo.
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib as mpl
+
+mpl.use("Agg")
+import matplotlib.pyplot as plt
+
+PHASES = ("encode_s", "denoise_s", "decode_s")
+PHASE_COLORS = {"encode_s": "#8ecae6", "denoise_s": "#219ebc", "decode_s": "#ffb703"}
+MODEL_COLORS = ["#219ebc", "#d1495b", "#6a994e", "#7b2cbf", "#bc6c25", "#3a506b"]
+
+
+@dataclass(frozen=True)
+class Report:
+    label: str
+    runs: list[dict]
+    system: dict
+    git: dict
+    config: dict
+
+
+class BenchmarkPlot:
+    @staticmethod
+    def load_reports(paths: list[Path], labels: list[str] | None) -> list[Report]:
+        reports = []
+        for i, path in enumerate(paths):
+            data = json.loads(path.read_text())
+            label = labels[i] if labels else path.stem
+            reports.append(
+                Report(
+                    label=label,
+                    runs=data["runs"],
+                    system=data.get("system", {}),
+                    git=data.get("git", {}),
+                    config=data.get("config", {}),
+                )
+            )
+        return reports
+
+    @staticmethod
+    def best_runs(reports: list[Report]) -> dict[tuple[str, str], dict]:
+        # Min-total run per (file, model): the thermal-throttle-robust choice (see
+        # the sustained-load caveat in scripts/benchmark.py).
+        best = {}
+        for report in reports:
+            for run in report.runs:
+                key = (report.label, run["model"])
+                if key not in best or run["total_s"] < best[key]["total_s"]:
+                    best[key] = run
+        return best
+
+    @staticmethod
+    def model_order(reports: list[Report]) -> list[str]:
+        seen = []
+        for report in reports:
+            for run in report.runs:
+                if run["model"] not in seen:
+                    seen.append(run["model"])
+        return seen
+
+    @staticmethod
+    def delta_table(reports: list[Report]) -> list[dict]:
+        best = BenchmarkPlot.best_runs(reports)
+        baseline, *others = reports
+        rows = []
+        for model in BenchmarkPlot.model_order(reports):
+            before = best.get((baseline.label, model))
+            if before is None:
+                continue
+            row = {"model": model, "baseline_total_s": before["total_s"], "deltas": {}}
+            for report in others:
+                after = best.get((report.label, model))
+                if after is None:
+                    continue
+                row["deltas"][report.label] = {
+                    "total_s": after["total_s"],
+                    "total_pct": 100.0 * (after["total_s"] - before["total_s"]) / before["total_s"],
+                    "denoise_pct": 100.0 * (after["denoise_s"] - before["denoise_s"]) / before["denoise_s"],
+                }
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    def render(reports: list[Report], out: Path) -> None:
+        best = BenchmarkPlot.best_runs(reports)
+        models = BenchmarkPlot.model_order(reports)
+        n_files = len(reports)
+
+        fig, (ax_bars, ax_steps) = plt.subplots(
+            2, 1, figsize=(max(8.0, 1.6 * len(models) * n_files + 4), 9), height_ratios=[2, 1]
+        )
+        BenchmarkPlot._draw_bars(ax_bars, reports, models, best)
+        BenchmarkPlot._draw_steps(ax_steps, reports, models, best)
+        fig.suptitle(BenchmarkPlot._title(reports), fontsize=11)
+        fig.tight_layout()
+        fig.savefig(out, dpi=150)
+
+    @staticmethod
+    def _draw_bars(ax, reports: list[Report], models: list[str], best: dict) -> None:
+        hatches = [None, "//", "xx", "\\\\", "oo"]
+        width = 0.8 / len(reports)
+        for i, report in enumerate(reports):
+            hatch = hatches[i % len(hatches)]
+            for j, model in enumerate(models):
+                run = best.get((report.label, model))
+                if run is None:
+                    continue
+                x = j - 0.4 + width * (i + 0.5)
+                bottom = 0.0
+                for phase in PHASES:
+                    value = run[phase]
+                    ax.bar(
+                        x,
+                        value,
+                        width,
+                        bottom=bottom,
+                        color=PHASE_COLORS[phase],
+                        hatch=hatch,
+                        edgecolor="white",
+                        linewidth=0.5,
+                    )
+                    bottom += value
+                ax.text(x, bottom, f"{run['total_s']:.1f}s", ha="center", va="bottom", fontsize=9)
+
+        phase_handles = [plt.Rectangle((0, 0), 1, 1, facecolor=PHASE_COLORS[p]) for p in PHASES]
+        file_handles = [
+            plt.Rectangle((0, 0), 1, 1, facecolor="white", edgecolor="black", hatch=hatches[i % len(hatches)])
+            for i, r in enumerate(reports)
+        ]
+        ax.legend(
+            phase_handles + file_handles,
+            [p.removesuffix("_s") for p in PHASES] + [r.label for r in reports],
+            loc="upper right",
+            fontsize=8,
+        )
+        ax.set_xticks(range(len(models)))
+        ax.set_xticklabels([BenchmarkPlot._model_tick(models, best, m) for m in models], fontsize=9)
+        ax.set_ylabel("seconds (min-total run, stacked phases)")
+        ax.margins(y=0.15)
+
+    @staticmethod
+    def _draw_steps(ax, reports: list[Report], models: list[str], best: dict) -> None:
+        for i, report in enumerate(reports):
+            for j, model in enumerate(models):
+                run = best.get((report.label, model))
+                if run is None or not run["step_times_s"]:
+                    continue
+                ax.plot(
+                    range(1, len(run["step_times_s"]) + 1),
+                    run["step_times_s"],
+                    marker="o",
+                    markersize=3,
+                    color=MODEL_COLORS[j % len(MODEL_COLORS)],
+                    linestyle=("-" if i == 0 else "--"),
+                    alpha=0.9 if i == 0 else 0.7,
+                    label=f"{model} ({report.label})",
+                )
+        ax.set_xlabel("denoise step (shifted by one sync — relative shape only)")
+        ax.set_ylabel("seconds")
+        ax.legend(fontsize=8)
+
+    @staticmethod
+    def _model_tick(models: list[str], best: dict, model: str) -> str:
+        peaks = {run["peak_memory_gb"] for (label, m), run in best.items() if m == model}
+        peak_note = f"\npeak {max(peaks):.0f} GB" if len(peaks) == 1 else ""
+        return f"{model}{peak_note}"
+
+    @staticmethod
+    def _title(reports: list[Report]) -> str:
+        first = reports[0]
+        chip = first.system.get("chip") or first.system.get("os", "")
+        commits = " vs ".join(
+            f"{r.label}@{r.git.get('commit', '?')}{'*' if r.git.get('dirty') else ''}" for r in reports
+        )
+        cfg = first.config
+        shape = f"{cfg.get('width')}x{cfg.get('height')}, steps={cfg.get('steps')}, q{cfg.get('quantize')}"
+        return f"{chip} — {shape}\n{commits}  (* = dirty worktree)"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Plot benchmark JSON reports (A/B comparison) as a PNG.")
+    parser.add_argument("reports", nargs="+", type=Path, help="benchmark.py JSON output(s), baseline first")
+    parser.add_argument("--labels", nargs="*", default=None, help="Display label per report (default: file stem)")
+    parser.add_argument("--out", type=Path, default=Path("benchmark.png"))
+    args = parser.parse_args()
+
+    reports = BenchmarkPlot.load_reports(args.reports, args.labels)
+    BenchmarkPlot.render(reports, args.out)
+    print(f"wrote {args.out}")
+
+    if len(reports) > 1:
+        print(f"\n=== delta vs {reports[0].label} (min-total run per model) ===")
+        for row in BenchmarkPlot.delta_table(reports):
+            deltas = " | ".join(
+                f"{label}: total {d['total_s']:.1f}s ({d['total_pct']:+.1f}%), denoise {d['denoise_pct']:+.1f}%"
+                for label, d in row["deltas"].items()
+            )
+            print(f"  {row['model']}: baseline {row['baseline_total_s']:.1f}s | {deltas}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_benchmark_plot.py
+++ b/tests/test_benchmark_plot.py
@@ -1,0 +1,79 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+PLOT_PATH = Path(__file__).parent.parent / "scripts" / "benchmark_plot.py"
+spec = importlib.util.spec_from_file_location("benchmark_plot", PLOT_PATH)
+benchmark_plot = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(benchmark_plot)
+
+BenchmarkPlot = benchmark_plot.BenchmarkPlot
+
+
+def write_report(path: Path, runs: list[dict], label_config: dict | None = None) -> Path:
+    report = {
+        "schema_version": 1,
+        "created_at": "2026-08-26T00:00:00+0000",
+        "system": {"chip": "Apple M4 Max", "os": "macOS", "python": "3.13", "mlx": "0.32.0", "mflux": "0.19.1"},
+        "git": {"commit": "abc123", "dirty": False},
+        "config": label_config or {"prompt": "p", "seed": 42, "steps": 4, "width": 1024, "height": 1024, "quantize": 8},
+        "runs": runs,
+        "summary": [],
+    }
+    path.write_text(json.dumps(report))
+    return path
+
+
+def run(model: str, run_index: int, total: float) -> dict:
+    return {
+        "model": model,
+        "run_index": run_index,
+        "encode_s": 0.5,
+        "denoise_s": total - 1.5,
+        "decode_s": 1.0,
+        "total_s": total,
+        "step_times_s": [total / 4] * 4,
+        "peak_memory_gb": 36.0,
+    }
+
+
+@pytest.mark.fast
+def test_best_runs_picks_min_total_per_label_and_model(tmp_path):
+    before = write_report(tmp_path / "before.json", [run("m", 0, 30.0), run("m", 1, 25.0)])
+    after = write_report(tmp_path / "after.json", [run("m", 0, 20.0), run("m", 1, 22.0)])
+    reports = BenchmarkPlot.load_reports([before, after], labels=["before", "after"])
+
+    best = BenchmarkPlot.best_runs(reports)
+
+    assert best[("before", "m")]["total_s"] == 25.0
+    assert best[("after", "m")]["total_s"] == 20.0
+
+
+@pytest.mark.fast
+def test_delta_table_computes_percentages_against_first_report(tmp_path):
+    before = write_report(tmp_path / "before.json", [run("m", 0, 40.0)])
+    after = write_report(tmp_path / "after.json", [run("m", 0, 30.0)])
+    reports = BenchmarkPlot.load_reports([before, after], labels=None)
+
+    rows = BenchmarkPlot.delta_table(reports)
+
+    assert len(rows) == 1
+    delta = rows[0]["deltas"]["after"]
+    assert delta["total_s"] == 30.0
+    assert delta["total_pct"] == -25.0
+    assert delta["denoise_pct"] == pytest.approx(100.0 * (28.5 - 38.5) / 38.5)
+
+
+@pytest.mark.fast
+def test_render_writes_non_empty_png(tmp_path):
+    before = write_report(tmp_path / "before.json", [run("m", 0, 40.0), run("n", 0, 80.0)])
+    after = write_report(tmp_path / "after.json", [run("m", 0, 30.0)])
+    reports = BenchmarkPlot.load_reports([before, after], labels=None)
+    out = tmp_path / "chart.png"
+
+    BenchmarkPlot.render(reports, out)
+
+    assert out.stat().st_size > 10_000
+    assert out.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"

--- a/tests/test_benchmark_timer.py
+++ b/tests/test_benchmark_timer.py
@@ -1,0 +1,71 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+BENCHMARK_PATH = Path(__file__).parent.parent / "scripts" / "benchmark.py"
+spec = importlib.util.spec_from_file_location("benchmark", BENCHMARK_PATH)
+benchmark = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(benchmark)
+
+BenchmarkTimer = benchmark.BenchmarkTimer
+summarize = benchmark.Benchmark.summarize
+
+
+def driven_timer(stamps: list[float]) -> BenchmarkTimer:
+    clock = iter(stamps).__next__
+    timer = BenchmarkTimer(clock=clock)
+    timer.mark_start()
+    timer.call_before_loop(seed=0, prompt="", latents=None, config=None)
+    timer.call_in_loop(t=0, seed=0, prompt="", latents=None, config=None, time_steps=None)
+    timer.call_in_loop(t=1, seed=0, prompt="", latents=None, config=None, time_steps=None)
+    timer.call_after_loop(seed=0, prompt="", latents=None, config=None)
+    return timer
+
+
+@pytest.mark.fast
+def test_timer_computes_phase_durations():
+    timer = driven_timer([10.0, 12.0, 13.0, 15.0, 18.0])
+    result = timer.result(t_end=20.0, peak_memory_bytes=2_000_000_000)
+
+    assert result["encode_s"] == 2.0
+    assert result["denoise_s"] == 6.0
+    assert result["decode_s"] == 2.0
+    assert result["total_s"] == 10.0
+    assert result["step_times_s"] == [1.0, 2.0]
+    assert result["peak_memory_gb"] == 2.0
+
+
+@pytest.mark.fast
+def test_timer_mark_start_resets_between_runs():
+    timer = driven_timer([10.0, 12.0, 13.0, 15.0, 18.0])
+    timer.result(t_end=20.0, peak_memory_bytes=0)
+
+    timer.clock = iter([100.0, 110.0, 111.0, 112.0, 120.0]).__next__
+    timer.mark_start()
+    timer.call_before_loop(seed=0, prompt="", latents=None, config=None)
+    timer.call_in_loop(t=0, seed=0, prompt="", latents=None, config=None, time_steps=None)
+    timer.call_in_loop(t=1, seed=0, prompt="", latents=None, config=None, time_steps=None)
+    timer.call_after_loop(seed=0, prompt="", latents=None, config=None)
+    result = timer.result(t_end=125.0, peak_memory_bytes=0)
+
+    assert result["encode_s"] == 10.0
+    assert result["step_times_s"] == [1.0, 1.0]
+    assert result["total_s"] == 25.0
+
+
+@pytest.mark.fast
+def test_summarize_groups_per_model_with_min_and_median():
+    runs = [
+        {"model": "a", "total_s": 10.0, "denoise_s": 8.0},
+        {"model": "a", "total_s": 12.0, "denoise_s": 10.0},
+        {"model": "a", "total_s": 14.0, "denoise_s": 12.0},
+        {"model": "b", "total_s": 30.0, "denoise_s": 25.0},
+    ]
+
+    summary = summarize(runs)
+
+    assert summary == [
+        {"model": "a", "runs": 3, "total_min_s": 10.0, "total_median_s": 12.0, "denoise_median_s": 10.0},
+        {"model": "b", "runs": 1, "total_min_s": 30.0, "total_median_s": 30.0, "denoise_median_s": 25.0},
+    ]


### PR DESCRIPTION
Plan to do some perf improvements, but should have measurements in place to make sure things actually will.. improve =)

for now these are just as-is readings of status quo perf

<img width="1200" height="1350" alt="image" src="https://github.com/user-attachments/assets/24dd5628-467f-4f9a-b287-f75f1d994b5c" />

<img width="1560" height="1350" alt="image" src="https://github.com/user-attachments/assets/a7cc281e-0e60-4c57-ade0-75330a9d1edf" />

## What

Adds the measurement foundation for a planned `mx.compile` usage/coverage perf improvement rollout (plan: compile is live on 6 variants but the denoise loops of FLUX.1, Qwen, boogu, fibo, and lens run eager, and every loop hard-syncs per step). Before touching those hot paths we need a fixed-seed A/B harness so each compile PR can be judged numerically, not by vibes.

Two new repo tools (nothing packaged, no new dependencies — matplotlib is already a main dep):

- **`scripts/benchmark.py`** — per-phase wall times (text encode / denoise / decode) + peak MLX GB per run. Registers a timer on the existing callback registry (`BenchmarkTimer`) and reuses the CLI's non-low-ram `MemorySaver` path so numbers reflect real generation behavior. Covers the 8 txt2img families in scope for compile work (`z-image-turbo`, `qwen-image`, `krea-2`, `boogu-image-turbo`, `fibo`, `lens-turbo`, `dev`, `schnell`) via a one-row-per-model registry; step defaults come from the existing `model_inference_steps()`. Writes a JSON report embedding chip/OS/Python/MLX versions + git SHA/dirty flag, so before/after reports are self-describing.
- **`scripts/benchmark_plot.py`** — renders one or more reports as a comparison PNG (stacked encode/denoise/decode bars, hatch per report; per-step denoise lines; peak-GB tick labels) and prints a per-model delta table vs the baseline report.

Wrapped by two justfile recipes (`just benchmark`, `just benchmark-plot`) with worked examples in JUSTFILE.md, including the thermal-throttle gotcha: sustained long sessions throttled ~1.7× on an M4 Max while short bursts held ±1.3%, so A/B decisions should use min/median of short runs — which `summary` prints.

Tests: `tests/test_benchmark_timer.py` (phase math via injected fake clock, per-run state reset, summary stats) and `tests/test_benchmark_plot.py` (min-run selection, delta math, real PNG render smoke test), all `@pytest.mark.fast`.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default (selector: `-m "not slow and not high_memory_requirement"`, same as `just test`). Only mark `@pytest.mark.slow` or `@pytest.mark.high_memory_requirement` when a test exceeds CI's time or memory budget (typically weight downloads / image generation).
- [x] `ruff check` and `ruff format` are clean (`uv run ruff` uses the version pinned in the dev dependencies of `pyproject.toml`, which is the single source of truth for pre-commit and CI; `pre-commit run -a` covers it locally).
- [x] `CHANGELOG.md`: entry under `Unreleased` referencing this PR number. (#685)
- [x] Docs updated where behavior changed — README examples/table rows are part of the API contract (see `.cursor/rules/RULE.md`). JUSTFILE.md gained a Benchmarking section; no user-facing CLI/model behavior changed.
- [ ] New model: shared config wiring (aliases, default steps, mflux-save dispatch, capabilities, completions), thin CLI entrypoint, and `src/mflux/models/<name>/README.md`. (N/A — no new model)
- [ ] New/changed CLI: ignored/rejected options declared (`IGNORED_OPTIONS`/`REJECTED_OPTIONS`) and `warn_ignored_options` actually called in `main()` — `mflux-capabilities` must stay truthful. (N/A — scripts are repo tooling, not registered mflux CLIs)

## Verification

- `uv run pytest tests/test_benchmark_timer.py tests/test_benchmark_plot.py -q` → 6 passed
- `just test-fast` → 1333 passed, 3 skipped (includes the 6 new fast-marked tests)
- `just lint`, `just lint-justfile`, pre-commit (`ruff`, `ruff format`, `typos`, `ty`) → clean
- Real runs on M4 Max (128 GB), z-image-turbo q8:
  - `just benchmark z-image-turbo 8 1 512` → 17.1s total, 9 steps ≈ 1.8 s/it, report written with provenance header
  - 4-step ×4-run session stable to ±1.3%; a 9-step ×2-run session showed run 1 at ~1.7× run 0 step time (thermal) — documented in the script header and JUSTFILE.md
  - `just benchmark-plot <before>.json <after>.json` → `benchmark.png` rendered (1200×1350) + delta table printed; single-report mode verified too
- Offline slow-test pass with this branch: 13 cache-satisfiable slow tests green under `HF_HUB_OFFLINE=1` (no downloads; HF cache size unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-phase generation benchmarking for encode, denoise, and decode performance, including timing and peak memory metrics.
  - Added support for benchmarking multiple models and configurable runs, image sizes, steps, guidance, and quantization.
  - Added chart generation for comparing benchmark reports, with phase breakdowns, denoise trends, and performance deltas.

- **Documentation**
  - Added usage guidance for running benchmarks and interpreting generated reports.

- **Chores**
  - Added generated benchmark artifacts to ignore rules.
  - Corrected a typo in the installation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->