### PR TITLE
fix: restricted CLIs infer the family sibling from a custom checkpoint's name again

### DIFF
--- a/src/mflux/models/common/resolution/config_resolution.py
+++ b/src/mflux/models/common/resolution/config_resolution.py
@@ -90,6 +90,20 @@ class ConfigResolution:
         return resolved
 
     @staticmethod
+    def infer_family_member(
+        model_path: str, registry_key: str, extra_keys: tuple[str, ...] = ()
+    ) -> "ModelConfig | None":
+        # The entry a custom checkpoint's name selects within a restricted CLI's family, or
+        # None when the name carries no family alias. resolve_restricted uses it for the
+        # geometry; the flux2 commands ask it again to learn whether the name, rather than
+        # the fallback, chose the config (a name that spells the default entry must be
+        # judged like the default entry, not like an unknown checkpoint).
+        from mflux.models.common.config.model_config import AVAILABLE_MODELS
+
+        allowed = [AVAILABLE_MODELS[registry_key]] + [AVAILABLE_MODELS[key] for key in extra_keys]
+        return ConfigResolution._infer_from_name(model_path, allowed)
+
+    @staticmethod
     def _infer_from_name(name: str, candidates: list["ModelConfig"]) -> "ModelConfig | None":
         # Shared by the INFER_SUBSTRING rule and resolve_restricted so the two cannot drift: the
         # longest matching alias wins (a "flux2-klein-base-9b" name is not claimed by "flux2-klein"),

--- a/src/mflux/models/common/resolution/config_resolution.py
+++ b/src/mflux/models/common/resolution/config_resolution.py
@@ -53,9 +53,12 @@ class ConfigResolution:
         # Resolve --model for a CLI hard-wired to one registry model or a closed family of them: `registry_key` is the
         # entry an omitted --model runs; `extra_keys` are siblings this CLI can equally serve. A builtin name must alias
         # one of these — anything else errors instead of silently loading a foreign config. Custom checkpoints (model_path
-        # set) keep the default entry's geometry while weights load from the path; an explicit base_model selects a family
-        # entry for them, and naming anything outside the family is an error. Compared by identity: entries can share a
-        # repo id.
+        # set) load their weights from the path and take their geometry from the family: an explicit base_model selects
+        # the entry (naming anything outside the family is an error); without it the checkpoint's name is searched for a
+        # family alias, the way from_name inferred it before #650, so mlx-community/flux2-klein-9b-8bit runs as klein-9b
+        # rather than dying inside attention on the default entry's shapes, and a turbo-named z-image checkpoint runs as
+        # z-image-turbo. Only the family is searched, so an unrelated name (~/models/my-finetune) keeps the default entry
+        # instead of being rejected. Compared by identity: entries can share a repo id.
         from mflux.models.common.config.model_config import AVAILABLE_MODELS
         from mflux.utils.exceptions import ModelConfigError
 
@@ -73,6 +76,10 @@ class ConfigResolution:
                         f"'{base_model}' is not {expected.model_name}; this CLI only accepts the aliases {aliases}."
                     )
                 return root
+            if model_path is not None:
+                inferred = ConfigResolution._infer_from_name(model_path, allowed)
+                if inferred is not None:
+                    return inferred
             return expected
         resolved = ConfigResolution.resolve(model_name=model_name)
         if all(resolved is not config for config in allowed):
@@ -81,6 +88,19 @@ class ConfigResolution:
                 f"'{model_name}' is not {expected.model_name}; this CLI only accepts the aliases {aliases}."
             )
         return resolved
+
+    @staticmethod
+    def _infer_from_name(name: str, candidates: list["ModelConfig"]) -> "ModelConfig | None":
+        # Shared by the INFER_SUBSTRING rule and resolve_restricted so the two cannot drift: the
+        # longest matching alias wins (a "flux2-klein-base-9b" name is not claimed by "flux2-klein"),
+        # then registry priority. None when no alias appears in the name.
+        lowered = name.lower()
+        matches = [
+            (config, alias) for config in candidates for alias in config.aliases if alias and alias.lower() in lowered
+        ]
+        if not matches:
+            return None
+        return sorted(matches, key=lambda match: (-len(match[1]), match[0].priority))[0][0]
 
     @staticmethod
     def _resolve(model_name: str | None, base_model: str | None = None) -> tuple["ModelConfig", "ModelConfig"]:
@@ -201,14 +221,9 @@ class ConfigResolution:
             return ConfigResolution._create_config(model_name, default_base), default_base
 
         if action == ConfigAction.INFER_SUBSTRING:
-            model_name_lower = model_name.lower()
-            matching_bases = [
-                (b, alias) for b in base_models for alias in b.aliases if alias and alias.lower() in model_name_lower
-            ]
-            if not matching_bases:
+            default_base = ConfigResolution._infer_from_name(model_name, base_models)
+            if default_base is None:
                 raise ModelConfigError(f"Cannot infer base_model from {model_name}")
-
-            default_base = sorted(matching_bases, key=lambda x: (-len(x[1]), x[0].priority))[0][0]
             return ConfigResolution._create_config(model_name, default_base), default_base
 
         if action == ConfigAction.ERROR:

--- a/src/mflux/models/flux2/cli/flux2_edit_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_edit_generate.py
@@ -67,10 +67,13 @@ def main():
     # substring sniff for "is it flux2 at all" was the only guard and distilled
     # checkpoints slipped through it.
     # Judged whenever the resolved config reflects the loaded weights: a builtin name always does; so does a custom
-    # checkpoint (model_path set) once --base-model declared one of the family's entries, since that is what selects
-    # its geometry. Without the flag it keeps the default entry's config, whose name says nothing about the weights
-    # actually loaded — a klein-base fine-tune must not have its guidance rejected for an unknown checkpoint.
-    judged = args.model_path is None or args.base_model is not None
+    # checkpoint (model_path set) once --base-model declared one of the family's entries, or once its name selected
+    # a sibling (a name trusted for the geometry is trusted for the distillation too; a klein-base fine-tune with a
+    # misleading name declares itself with --base-model). A name that matches nothing keeps the default entry's
+    # config, whose name says nothing about the weights actually loaded, so it stays unjudged.
+    judged = (
+        args.model_path is None or args.base_model is not None or model_config is not AVAILABLE_MODELS[DEFAULT_MODEL]
+    )
     if judged and args.guidance != 1.0 and "base" not in model_config.model_name.lower():
         parser.error("--guidance is only supported for FLUX.2 base models. Use --guidance 1.0.")
 

--- a/src/mflux/models/flux2/cli/flux2_edit_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_edit_generate.py
@@ -70,10 +70,11 @@ def main():
     # checkpoint (model_path set) once --base-model declared one of the family's entries, or once its name selected
     # a sibling (a name trusted for the geometry is trusted for the distillation too; a klein-base fine-tune with a
     # misleading name declares itself with --base-model). A name that matches nothing keeps the default entry's
-    # config, whose name says nothing about the weights actually loaded, so it stays unjudged.
-    judged = (
-        args.model_path is None or args.base_model is not None or model_config is not AVAILABLE_MODELS[DEFAULT_MODEL]
-    )
+    # config, whose name says nothing about the weights actually loaded, so it stays unjudged. Asked by name rather
+    # than by comparing configs: a checkpoint spelled after the default entry resolves to that same object.
+    named = args.model_path is not None and args.base_model is None
+    named = named and ConfigResolution.infer_family_member(args.model_path, DEFAULT_MODEL, FAMILY_MODELS) is not None
+    judged = args.model_path is None or args.base_model is not None or named
     if judged and args.guidance != 1.0 and "base" not in model_config.model_name.lower():
         parser.error("--guidance is only supported for FLUX.2 base models. Use --guidance 1.0.")
 

--- a/src/mflux/models/flux2/cli/flux2_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_generate.py
@@ -66,10 +66,11 @@ def main():
     # checkpoint (model_path set) once --base-model declared one of the family's entries, or once its name selected
     # a sibling (a name trusted for the geometry is trusted for the distillation too; a klein-base fine-tune with a
     # misleading name declares itself with --base-model). A name that matches nothing keeps the default entry's
-    # config, whose name says nothing about the weights actually loaded, so it stays unjudged.
-    judged = (
-        args.model_path is None or args.base_model is not None or model_config is not AVAILABLE_MODELS[DEFAULT_MODEL]
-    )
+    # config, whose name says nothing about the weights actually loaded, so it stays unjudged. Asked by name rather
+    # than by comparing configs: a checkpoint spelled after the default entry resolves to that same object.
+    named = args.model_path is not None and args.base_model is None
+    named = named and ConfigResolution.infer_family_member(args.model_path, DEFAULT_MODEL, FAMILY_MODELS) is not None
+    judged = args.model_path is None or args.base_model is not None or named
     if judged and args.guidance != 1.0 and "base" not in model_config.model_name.lower():
         parser.error("--guidance is only supported for FLUX.2 base models. Use --guidance 1.0.")
 

--- a/src/mflux/models/flux2/cli/flux2_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_generate.py
@@ -63,10 +63,13 @@ def main():
     if args.guidance is None:
         args.guidance = 1.0
     # Judged whenever the resolved config reflects the loaded weights: a builtin name always does; so does a custom
-    # checkpoint (model_path set) once --base-model declared one of the family's entries, since that is what selects
-    # its geometry. Without the flag it keeps the default entry's config, whose name says nothing about the weights
-    # actually loaded — a klein-base fine-tune must not have its guidance rejected for an unknown checkpoint.
-    judged = args.model_path is None or args.base_model is not None
+    # checkpoint (model_path set) once --base-model declared one of the family's entries, or once its name selected
+    # a sibling (a name trusted for the geometry is trusted for the distillation too; a klein-base fine-tune with a
+    # misleading name declares itself with --base-model). A name that matches nothing keeps the default entry's
+    # config, whose name says nothing about the weights actually loaded, so it stays unjudged.
+    judged = (
+        args.model_path is None or args.base_model is not None or model_config is not AVAILABLE_MODELS[DEFAULT_MODEL]
+    )
     if judged and args.guidance != 1.0 and "base" not in model_config.model_name.lower():
         parser.error("--guidance is only supported for FLUX.2 base models. Use --guidance 1.0.")
 

--- a/tests/test_restricted_model_cli.py
+++ b/tests/test_restricted_model_cli.py
@@ -4,8 +4,9 @@
 # ernie CLIs). Each single-model CLI now routes --model through
 # ConfigResolution.resolve_restricted: builtin registry names must be an alias of the
 # CLI's own model, while paths and HuggingFace repo ids (which parse_args marks by
-# setting model_path) keep the CLI's own config and load weights from the path, as they
-# always have.
+# setting model_path) load weights from the path and take their config from the family:
+# --base-model names the entry, a family alias in the name selects it (#694), and any
+# other name keeps the CLI's own config.
 
 import sys
 from types import SimpleNamespace
@@ -183,8 +184,9 @@ FLUX2_BASE_ARGV = [
 @pytest.mark.fast
 class TestFlux2BaseModelPassthrough:
     # --base-model is parsed and validated by the general argument set, but only the flux2
-    # commands pass it to resolution. A custom checkpoint (repo id or local path) otherwise
-    # always runs on the CLI default's geometry, which corrupts any family sibling whose
+    # commands pass it to resolution. Without it a custom checkpoint (repo id or local path)
+    # runs on the sibling its name carries, or on the CLI default's geometry when it carries
+    # none; before #694 it always got the default, which corrupts any family sibling whose
     # transformer differs — a community klein-9b checkpoint reshaped as a 4B dies at its
     # first attention layer.
     @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
@@ -228,17 +230,63 @@ class TestFlux2BaseModelPassthrough:
             )
 
     @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
-    def test_custom_checkpoint_without_base_keeps_cli_config(self, monkeypatch, module, base_argv):
-        # No flag: unchanged behavior — the checkpoint runs on the CLI default's geometry.
+    def test_unrelated_checkpoint_without_base_keeps_cli_config(self, monkeypatch, module, base_argv):
+        # No flag and no family alias in the name: the checkpoint runs on the CLI default's geometry.
+        config = TestRestrictedModelConfig._resolve_via_parser(
+            monkeypatch,
+            module,
+            "flux2-klein-4b",
+            extra_argv=["--model", "/tmp/models/my-finetune-q8"],
+            extra_keys=module.FAMILY_MODELS,
+            base_argv=base_argv,
+        )
+        assert config is AVAILABLE_MODELS["flux2-klein-4b"]
+
+    # No flag, but the name carries a family alias: the sibling is inferred from it, as from_name did
+    # before #650 (#694). Longest alias wins, so "base" and "kv" names are not claimed by the plain
+    # "flux2-klein" alias of the default entry.
+    @pytest.mark.parametrize(
+        "checkpoint,expected_key",
+        [
+            ("mlx-community/flux2-klein-9b-8bit", "flux2-klein-9b"),
+            ("mlx-community/flux2-klein-base-9b-8bit", "flux2-klein-base-9b"),
+            ("/Volumes/models/flux2-klein-base-4b-q8", "flux2-klein-base-4b"),
+            ("someone/Flux2-Klein-9B-KV-4bit", "flux2-klein-9b-kv"),
+            ("mlx-community/flux2-klein-4b-8bit", "flux2-klein-4b"),
+            # The official repo ids are not builtin names either; they infer through the short aliases.
+            ("black-forest-labs/FLUX.2-klein-9B", "flux2-klein-9b"),
+            ("black-forest-labs/FLUX.2-klein-9b-kv", "flux2-klein-9b-kv"),
+            ("black-forest-labs/FLUX.2-klein-base-9B", "flux2-klein-base-9b"),
+        ],
+    )
+    @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
+    def test_family_alias_in_checkpoint_name_selects_sibling(
+        self, monkeypatch, module, base_argv, checkpoint, expected_key
+    ):
+        config = TestRestrictedModelConfig._resolve_via_parser(
+            monkeypatch,
+            module,
+            "flux2-klein-4b",
+            extra_argv=["--model", checkpoint],
+            extra_keys=module.FAMILY_MODELS,
+            base_argv=base_argv,
+        )
+        assert config is AVAILABLE_MODELS[expected_key]
+
+    @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
+    def test_explicit_base_overrides_name_inference(self, monkeypatch, module, base_argv):
+        # The flag is the explicit control: a checkpoint whose name says 9b but is declared as klein-base-9b
+        # runs as klein-base-9b.
         config = TestRestrictedModelConfig._resolve_via_parser(
             monkeypatch,
             module,
             "flux2-klein-4b",
             extra_argv=["--model", "mlx-community/flux2-klein-9b-8bit"],
             extra_keys=module.FAMILY_MODELS,
+            base_model="flux2-klein-base-9b",
             base_argv=base_argv,
         )
-        assert config is AVAILABLE_MODELS["flux2-klein-4b"]
+        assert config is AVAILABLE_MODELS["flux2-klein-base-9b"]
 
     # Runs main() until model construction and stops inside stubbed generate_image (SystemExit 0), so tests can
     # assert that argument-level validation let an invocation through without loading any weights.
@@ -301,6 +349,43 @@ class TestFlux2BaseModelPassthrough:
         assert exit_code == 0
 
     @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
+    def test_inferred_distilled_name_rejects_guidance(self, monkeypatch, module, base_argv):
+        # The name selected klein-9b for the geometry, so it is trusted for the distillation too (#694): the same
+        # rejection as the builtin name or the explicit flag, instead of CFG silently running on distilled weights.
+        argv = (
+            "--model",
+            "mlx-community/flux2-klein-9b-8bit",
+            "--width",
+            "512",
+            "--height",
+            "512",
+            "--guidance",
+            "3.0",
+            *base_argv,
+        )
+        monkeypatch.setattr(sys, "argv", ["prog", "--prompt", "test", *argv])
+        with pytest.raises(SystemExit) as exit_info:
+            module.main()
+        assert exit_info.value.code == 2
+
+    @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
+    def test_inferred_base_name_keeps_guidance(self, monkeypatch, module, base_argv):
+        exit_code = self._run_main_until_generation(
+            monkeypatch,
+            module,
+            "--model",
+            "mlx-community/flux2-klein-base-9b-8bit",
+            "--width",
+            "512",
+            "--height",
+            "512",
+            "--guidance",
+            "3.0",
+            *base_argv,
+        )
+        assert exit_code == 0
+
+    @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
     def test_custom_checkpoint_without_base_keeps_guidance_unjudged(self, monkeypatch, module, base_argv):
         # No --base-model: the checkpoint's lineage is unknown (it may be a klein-base fine-tune), so guidance stays unjudged.
         exit_code = self._run_main_until_generation(
@@ -317,3 +402,32 @@ class TestFlux2BaseModelPassthrough:
             *base_argv,
         )
         assert exit_code == 0
+
+
+@pytest.mark.fast
+class TestZImageFamilyInference:
+    # The z-image CLI serves z-image and its distilled sibling, so the same name inference
+    # applies (#694): a turbo-named checkpoint runs with guidance forced off instead of CFG
+    # over distilled weights. The ControlNet entry is not in this family, so its name lands
+    # on turbo, never on the ControlNet config.
+    @pytest.mark.parametrize(
+        "checkpoint,expected_key",
+        [
+            ("mlx-community/Z-Image-Turbo-8bit", "z-image-turbo"),
+            ("/models/zimage-turbo-q8", "z-image-turbo"),
+            ("Tongyi-MAI/Z-Image-Turbo", "z-image-turbo"),
+            ("/models/z-image-turbo-controlnet-q8", "z-image-turbo"),
+            ("/models/zimage-q8", "z-image"),
+            ("Tongyi-MAI/Z-Image", "z-image"),
+            ("/models/my-finetune", "z-image"),
+        ],
+    )
+    def test_family_alias_in_checkpoint_name_selects_sibling(self, monkeypatch, checkpoint, expected_key):
+        config = TestRestrictedModelConfig._resolve_via_parser(
+            monkeypatch,
+            z_image_generate,
+            "z-image",
+            ["--model", checkpoint],
+            extra_keys=z_image_generate.FAMILY_MODELS,
+        )
+        assert config is AVAILABLE_MODELS[expected_key]

--- a/tests/test_restricted_model_cli.py
+++ b/tests/test_restricted_model_cli.py
@@ -310,7 +310,10 @@ class TestFlux2BaseModelPassthrough:
     def test_explicit_distilled_base_rejects_guidance(self, monkeypatch, module, base_argv):
         # Once --base-model names a distilled entry the checkpoint's lineage is known, so it must get the same guidance
         # rejection as its builtin name; before this flag existed that invocation died at model load instead of here.
-        argv = (
+        # Through the stub, so a regression ends in exit 0 rather than in a weight download.
+        exit_code = self._run_main_until_generation(
+            monkeypatch,
+            module,
             "--model",
             "mlx-community/flux2-klein-9b-8bit",
             "--base-model",
@@ -323,10 +326,7 @@ class TestFlux2BaseModelPassthrough:
             "3.0",
             *base_argv,
         )
-        monkeypatch.setattr(sys, "argv", ["prog", "--prompt", "test", *argv])
-        with pytest.raises(SystemExit) as exit_info:
-            module.main()
-        assert exit_info.value.code == 2
+        assert exit_code == 2
 
     @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
     def test_explicit_base_entry_keeps_guidance(self, monkeypatch, module, base_argv):
@@ -348,13 +348,19 @@ class TestFlux2BaseModelPassthrough:
         )
         assert exit_code == 0
 
+    # A name spelled after the default entry resolves to the very same object as the fallback, so the guard must
+    # ask the name, not compare configs, or a klein-4b checkpoint would slip past it.
+    @pytest.mark.parametrize("checkpoint", ["mlx-community/flux2-klein-9b-8bit", "mlx-community/flux2-klein-4b-8bit"])
     @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
-    def test_inferred_distilled_name_rejects_guidance(self, monkeypatch, module, base_argv):
-        # The name selected klein-9b for the geometry, so it is trusted for the distillation too (#694): the same
-        # rejection as the builtin name or the explicit flag, instead of CFG silently running on distilled weights.
-        argv = (
+    def test_inferred_distilled_name_rejects_guidance(self, monkeypatch, module, base_argv, checkpoint):
+        # The name selected a distilled entry for the geometry, so it is trusted for the distillation too (#694):
+        # the same rejection as the builtin name or the explicit flag, instead of CFG silently running on distilled
+        # weights. Through the stub, so a regression ends in exit 0 rather than in a weight download.
+        exit_code = self._run_main_until_generation(
+            monkeypatch,
+            module,
             "--model",
-            "mlx-community/flux2-klein-9b-8bit",
+            checkpoint,
             "--width",
             "512",
             "--height",
@@ -363,10 +369,7 @@ class TestFlux2BaseModelPassthrough:
             "3.0",
             *base_argv,
         )
-        monkeypatch.setattr(sys, "argv", ["prog", "--prompt", "test", *argv])
-        with pytest.raises(SystemExit) as exit_info:
-            module.main()
-        assert exit_info.value.code == 2
+        assert exit_code == 2
 
     @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
     def test_inferred_base_name_keeps_guidance(self, monkeypatch, module, base_argv):


### PR DESCRIPTION
## What

Since #650 a non-builtin `--model` (HF repo id or local path) on the flux2 and z-image commands always ran on the CLI default entry, so `mflux-generate-flux2 --model mlx-community/flux2-klein-9b-8bit` loaded 9B weights into the klein-4b config and died inside attention with `ValueError: [reshape] Cannot reshape array of size 4194304 into shape (1,1024,24,128)`. #688 added the explicit `--base-model` route; this restores the name inference `from_name` did before #650, but only within the CLI's family: the longest family alias in the name selects the sibling, anything else keeps the default entry (an unrelated name is never rejected, which is what #650 guarded against). The INFER_SUBSTRING rule and `resolve_restricted` now share one tie-break helper.

Two consequences, both deliberate:

- the flux2 guidance guard judges an inferred sibling like a builtin name or an explicit flag: a name trusted for the geometry is trusted for the distillation too, so `--model ...klein-9b-8bit --guidance 3.0` exits 2 instead of silently running CFG on distilled weights. A klein-base fine-tune with a misleading name declares itself with `--base-model`;
- the z-image CLI has the same two-entry family, so a turbo-named checkpoint now runs as z-image-turbo (guidance forced off) instead of CFG over distilled weights. The ControlNet entry is not in that family; its name lands on turbo.

Fixes #694.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default: flux2 inference cases (community and official repo ids, local paths, case variants, unrelated name, flag overriding the name), the guidance cases at `main()` level (inferred distilled rejects, inferred base keeps, unknown name stays unjudged), and the z-image family cases.
- [x] `ruff check` and `ruff format` are clean.
- [x] `CHANGELOG.md`: no entry; the release note block below carries it.
- [n/a] Docs updated where behavior changed.
- [n/a] New model.
- [n/a] New/changed CLI options.

## Verification

On the M5 with flux2-klein-9b saved at q8 to a local path named `flux2-klein-9b-q8` (same `model_path` route as a cached repo id), 512x512, 4 steps, seed 7:

- no flag: generates on the 9B geometry; pixel-identical to the same run with `--base-model flux2-klein-9b` (max abs diff 0). On main it dies with the reshape error above.
- no flag, `--guidance 3.0`: exits 2 with "--guidance is only supported for FLUX.2 base models" before loading weights.
- `--base-model dev`: the #688 ModelConfigError with the family's alias list.

Full fast suite: 1536 passed, `ty` clean.

## Release note

```release-note
mflux-generate-flux2 and mflux-generate-z-image pick the family sibling from a custom checkpoint's name again (mlx-community/flux2-klein-9b-8bit runs as klein-9b without --base-model); a name that matches nothing keeps the command's default model.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Custom checkpoint names now automatically select the matching model family, including FLUX.2 and Z-Image variants.
  - Explicit base-model selections take precedence over inferred checkpoint names.
  - Checkpoints with distilled, turbo, or controlnet names now select the appropriate model configuration.

- **Bug Fixes**
  - Guidance validation now correctly applies to inferred model variants.
  - Improved handling of custom checkpoint paths across supported command-line tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR restores family-restricted sibling inference for custom FLUX.2 and Z-Image checkpoint names and extends FLUX.2 guidance validation to inferred siblings.
- Adds a shared longest-alias inference helper to restricted model resolution.
- Applies inferred lineage to FLUX.2 guidance validation in generation and edit commands.
- Adds regression coverage for repository IDs, local paths, explicit overrides, guidance, and Z-Image sibling selection.
</details>


<h3>Confidence Score: 3/5</h3>

The PR should not merge until inferred checkpoints receive their resolved model’s step defaults and default-sibling FLUX.2 checkpoints are included in distilled guidance validation.

Custom checkpoint names are resolved only after the parser commits to a generic 25-step schedule, and the identity-based guidance guard allows inferred distilled Klein 4B checkpoints to execute unsupported classifier-free guidance.

**Files Needing Attention:** src/mflux/models/common/resolution/config_resolution.py, src/mflux/models/flux2/cli/flux2_generate.py, src/mflux/models/flux2/cli/flux2_edit_generate.py

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mflux/models/common/resolution/config_resolution.py | Adds shared family-alias inference, but inferred model selection occurs after parser defaults have already been finalized. |
| src/mflux/models/flux2/cli/flux2_generate.py | Extends guidance validation to inferred siblings, but skips validation when inference selects the default distilled registry object. |
| src/mflux/models/flux2/cli/flux2_edit_generate.py | Mirrors the generation command’s identity-based guidance gap for inferred Klein 4B checkpoints. |
| tests/test_restricted_model_cli.py | Thoroughly covers sibling resolution and non-default guidance cases but omits inferred model step defaults and guidance on an inferred default Klein 4B checkpoint. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Custom checkpoint name] --> B[CLI parser]
  B --> C[Steps selected from raw name]
  C --> D[Restricted family resolution]
  D --> E[Infer sibling by longest alias]
  E --> F[Guidance validation]
  F --> G[Construct family model]
  G --> H[Generate with previously selected steps]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20mflux-community%2Fmflux%20PR%20%23697%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=mflux-community%2Fmflux&pr=697&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fmflux%2Fmodels%2Fcommon%2Fresolution%2Fconfig_resolution.py%3A79-82%0A**Inferred%20models%20keep%20wrong%20steps**%0A%0AWhen%20a%20custom%20checkpoint%20such%20as%20%60mlx-community%2Fflux2-klein-9b-8bit%60%20or%20%60mlx-community%2FZ-Image-Turbo-8bit%60%20is%20used%20without%20%60--steps%60%2C%20parsing%20assigns%20the%20generic%2025-step%20default%20before%20this%20code%20infers%20the%20sibling.%20The%20checkpoint%20consequently%20runs%20with%2025%20steps%20instead%20of%20the%20resolved%20model's%20default%20of%204%2C%209%2C%20or%2050%2C%20so%20custom%20and%20built-in%20spellings%20of%20the%20same%20model%20use%20different%20denoising%20schedules.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fmflux%2Fmodels%2Fflux2%2Fcli%2Fflux2_generate.py%3A70-73%0A**Default%20sibling%20bypasses%20guidance%20guard**%0A%0AWhen%20a%20custom%20checkpoint%20name%20identifies%20the%20default%20distilled%20model%2C%20such%20as%20%60mlx-community%2Fflux2-klein-4b-8bit%60%2C%20resolution%20returns%20the%20exact%20default%20registry%20object%20and%20this%20identity%20check%20leaves%20%60judged%60%20false.%20The%20CLI%20therefore%20accepts%20guidance%20such%20as%20%603.0%60%20and%20executes%20classifier-free%20guidance%20on%20distilled%20Klein%204B%20weights%20instead%20of%20returning%20the%20documented%20argument%20error%3B%20the%20edit%20command%20has%20the%20same%20condition.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mflux-community%2Fmflux&pr=697&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/mflux/models/common/resolution/config_resolution.py:79-82
**Inferred models keep wrong steps**

When a custom checkpoint such as `mlx-community/flux2-klein-9b-8bit` or `mlx-community/Z-Image-Turbo-8bit` is used without `--steps`, parsing assigns the generic 25-step default before this code infers the sibling. The checkpoint consequently runs with 25 steps instead of the resolved model's default of 4, 9, or 50, so custom and built-in spellings of the same model use different denoising schedules.

### Issue 2
src/mflux/models/flux2/cli/flux2_generate.py:70-73
**Default sibling bypasses guidance guard**

When a custom checkpoint name identifies the default distilled model, such as `mlx-community/flux2-klein-4b-8bit`, resolution returns the exact default registry object and this identity check leaves `judged` false. The CLI therefore accepts guidance such as `3.0` and executes classifier-free guidance on distilled Klein 4B weights instead of returning the documented argument error; the edit command has the same condition.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: restricted CLIs infer the family si..."](https://github.com/mflux-community/mflux/commit/951cf18d403cceeae2c1571b37b7e890152cf500) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58525823)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Command-line interface](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/command-line-interface.md)
- Knowledge Base — [CLI parser and capabilities](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/cli-parser-and-capabilities.md)
- Knowledge Base — [FLUX.2 generation](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/flux2-generation.md)
- Knowledge Base — [Z-Image generation](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/z-image-generation.md)
</details>


<!-- /greptile_comment -->