### PR TITLE
fix: family inference reads only the checkpoint's basename, and z-image's --base-model reaches resolution

### DIFF
--- a/src/mflux/models/common/resolution/config_resolution.py
+++ b/src/mflux/models/common/resolution/config_resolution.py
@@ -77,7 +77,7 @@ class ConfigResolution:
                     )
                 return root
             if model_path is not None:
-                inferred = ConfigResolution._infer_from_name(model_path, allowed)
+                inferred = ConfigResolution.infer_family_member(model_path, registry_key, extra_keys)
                 if inferred is not None:
                     return inferred
             return expected
@@ -98,10 +98,19 @@ class ConfigResolution:
         # geometry; the flux2 commands ask it again to learn whether the name, rather than
         # the fallback, chose the config (a name that spells the default entry must be
         # judged like the default entry, not like an unknown checkpoint).
+        #
+        # An exact repo id wins outright; otherwise only the checkpoint's BASENAME is
+        # searched (#701): the basename is the only path segment that names the checkpoint,
+        # and a parent directory that happens to name a sibling
+        # (/Volumes/flux2-klein-9b-experiments/my-4b-finetune) must not reshape it.
         from mflux.models.common.config.model_config import AVAILABLE_MODELS
 
         allowed = [AVAILABLE_MODELS[registry_key]] + [AVAILABLE_MODELS[key] for key in extra_keys]
-        return ConfigResolution._infer_from_name(model_path, allowed)
+        exact = next((config for config in allowed if model_path == config.model_name), None)
+        if exact is not None:
+            return exact
+        basename = model_path.rstrip("/").rsplit("/", 1)[-1]
+        return ConfigResolution._infer_from_name(basename, allowed)
 
     @staticmethod
     def _infer_from_name(name: str, candidates: list["ModelConfig"]) -> "ModelConfig | None":

--- a/src/mflux/models/flux2/cli/flux2_edit_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_edit_generate.py
@@ -76,7 +76,7 @@ def main():
     named = named and ConfigResolution.infer_family_member(args.model_path, DEFAULT_MODEL, FAMILY_MODELS) is not None
     judged = args.model_path is None or args.base_model is not None or named
     if judged and args.guidance != 1.0 and "base" not in model_config.model_name.lower():
-        parser.error("--guidance is only supported for FLUX.2 base models. Use --guidance 1.0.")
+        parser.error("--guidance is only supported for FLUX.2 base models. Use --guidance 1.0, or declare a base checkpoint with --base-model.")  # fmt: off
 
     model = Flux2KleinEdit(
         model_config=model_config,

--- a/src/mflux/models/flux2/cli/flux2_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_generate.py
@@ -72,7 +72,7 @@ def main():
     named = named and ConfigResolution.infer_family_member(args.model_path, DEFAULT_MODEL, FAMILY_MODELS) is not None
     judged = args.model_path is None or args.base_model is not None or named
     if judged and args.guidance != 1.0 and "base" not in model_config.model_name.lower():
-        parser.error("--guidance is only supported for FLUX.2 base models. Use --guidance 1.0.")
+        parser.error("--guidance is only supported for FLUX.2 base models. Use --guidance 1.0, or declare a base checkpoint with --base-model.")  # fmt: off
 
     model = Flux2Klein(
         model_config=model_config,

--- a/src/mflux/models/z_image/cli/z_image_generate.py
+++ b/src/mflux/models/z_image/cli/z_image_generate.py
@@ -53,7 +53,11 @@ def main():
         args.scheduler = "flow_match_euler_discrete"
 
     model_config = ConfigResolution.resolve_restricted(
-        args.model, DEFAULT_MODEL, model_path=args.model_path, extra_keys=FAMILY_MODELS
+        args.model,
+        DEFAULT_MODEL,
+        model_path=args.model_path,
+        extra_keys=FAMILY_MODELS,
+        base_model=args.base_model,
     )
 
     # Warn on the EFFECTIVE behavior, not the flag value: --model may resolve to a

--- a/tests/metadata/test_generated_image.py
+++ b/tests/metadata/test_generated_image.py
@@ -272,3 +272,31 @@ def test_fibo_edit_prompt_json_tracks_final_output_name_when_image_exists(tmp_pa
     assert final_prompt_path.exists()
     assert not (tmp_path / "fibo_edit_output.json").exists()
     assert json.loads(final_prompt_path.read_text()) == json.loads(prompt)
+
+
+def test_custom_checkpoint_stores_the_base_it_resolved_to(tmp_path):
+    # The other half of the #695 fix, previously unpinned: a custom checkpoint declared
+    # with --base-model stores that base, and the stored value is one the --base-model
+    # validator accepts on replay.
+    from mflux.models.common.resolution.config_resolution import ConfigResolution
+
+    output_path = tmp_path / "generated.png"
+    generated_image = GeneratedImage(
+        image=Image.new("RGB", (16, 16), "white"),
+        model_config=ModelConfig.from_name("some-org/dev-finetune", base_model="dev"),
+        seed=42,
+        prompt="test prompt",
+        steps=20,
+        guidance=3.5,
+        precision=mx.bfloat16,
+        quantization=8,
+        generation_time=1.23,
+        height=16,
+        width=16,
+    )
+
+    generated_image.save(path=output_path, overwrite=True, export_json_metadata=True)
+
+    stored = json.loads(output_path.with_suffix(".metadata.json").read_text())
+    assert stored["base_model"] == "black-forest-labs/FLUX.1-dev"
+    assert stored["base_model"] in ConfigResolution.base_model_names()

--- a/tests/test_restricted_model_cli.py
+++ b/tests/test_restricted_model_cli.py
@@ -434,3 +434,76 @@ class TestZImageFamilyInference:
             extra_keys=z_image_generate.FAMILY_MODELS,
         )
         assert config is AVAILABLE_MODELS[expected_key]
+
+
+@pytest.mark.fast
+class TestFamilyInferenceHardening:
+    # #701: the basename is the only path segment that names the checkpoint. A parent
+    # directory naming a sibling must not reshape it, and the z-image CLI's --base-model
+    # must actually reach resolution.
+    @pytest.mark.parametrize("module,base_argv", FLUX2_BASE_ARGV, ids=lambda v: getattr(v, "__name__", v))
+    def test_parent_directory_alias_is_not_a_signal(self, monkeypatch, module, base_argv):
+        config = TestRestrictedModelConfig._resolve_via_parser(
+            monkeypatch,
+            module,
+            "flux2-klein-4b",
+            extra_argv=["--model", "/Volumes/flux2-klein-9b-experiments/my-4b-finetune"],
+            extra_keys=module.FAMILY_MODELS,
+            base_argv=base_argv,
+        )
+        assert config is AVAILABLE_MODELS["flux2-klein-4b"]
+
+    def test_z_image_base_model_overrides_the_name(self, monkeypatch):
+        # The turbo-named checkpoint is declared as the CFG-capable base entry: the flag
+        # must win over the name, which requires the CLI to pass it through (#701).
+        config = TestRestrictedModelConfig._resolve_via_parser(
+            monkeypatch,
+            z_image_generate,
+            "z-image",
+            ["--model", "mlx-community/Z-Image-Turbo-8bit"],
+            extra_keys=z_image_generate.FAMILY_MODELS,
+            base_model="z-image",
+        )
+        assert config is AVAILABLE_MODELS["z-image"]
+
+    def test_z_image_foreign_base_rejected(self, monkeypatch):
+        with pytest.raises(ModelConfigError, match="only accepts the aliases"):
+            TestRestrictedModelConfig._resolve_via_parser(
+                monkeypatch,
+                z_image_generate,
+                "z-image",
+                ["--model", "/models/finetune"],
+                extra_keys=z_image_generate.FAMILY_MODELS,
+                base_model="dev",
+            )
+
+    def test_z_image_parent_directory_alias_is_not_a_signal(self, monkeypatch):
+        config = TestRestrictedModelConfig._resolve_via_parser(
+            monkeypatch,
+            z_image_generate,
+            "z-image",
+            ["--model", "/models/z-image-turbo-stuff/finetune"],
+            extra_keys=z_image_generate.FAMILY_MODELS,
+        )
+        assert config is AVAILABLE_MODELS["z-image"]
+
+    def test_official_repo_id_still_selects_its_entry(self, monkeypatch):
+        # The exact repo id contains slashes, so it must match before the basename search.
+        config = TestRestrictedModelConfig._resolve_via_parser(
+            monkeypatch,
+            flux2_generate,
+            "flux2-klein-4b",
+            ["--model", "black-forest-labs/FLUX.2-klein-9B"],
+            extra_keys=flux2_generate.FAMILY_MODELS,
+        )
+        assert config is AVAILABLE_MODELS["flux2-klein-9b"]
+
+    def test_guidance_rejection_names_the_escape_hatch(self, monkeypatch, capsys):
+        with pytest.raises(SystemExit):
+            monkeypatch.setattr(
+                sys,
+                "argv",
+                ["prog", "--prompt", "t", "--model", "mlx-community/flux2-klein-9b-8bit", "--guidance", "3.0"],
+            )
+            flux2_generate.main()
+        assert "--base-model" in capsys.readouterr().err


### PR DESCRIPTION
## What

Follow-up to #697 from the adversarial review round. Three real gaps: the z-image command accepted `--base-model` but never passed it to `resolve_restricted`, so the escape hatch for name inference was dead on that CLI; family inference searched the whole `--model` string, so a parent directory naming a sibling (`/Volumes/flux2-klein-9b-experiments/my-4b-finetune`) reshaped a 4B checkpoint into 9B geometry and crashed where main used to run it — now an exact repo id wins outright and otherwise only the basename is searched; and the flux2 guidance rejection now names `--base-model` as the way out for a name-judged checkpoint. Also pins the other half of #695's writer fix (a custom checkpoint stores the base it resolved to, and the validator accepts it on replay) and deduplicates the family list through `infer_family_member`. Fixes #701.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default: parent-directory cases for flux2 and z-image, the z-image flag override and foreign-base rejection, the official-repo-id exact match, the guidance error text, and the custom-checkpoint writer case.
- [x] `ruff check` and `ruff format` are clean.
- [x] Release note block below filled in.
- [n/a] Docs updated where behavior changed.
- [n/a] New model.
- [n/a] New/changed CLI options.

## Verification

`tests/test_restricted_model_cli.py` 94 passed, `tests/metadata` green, full fast suite 1564 passed, `ty` clean. The parent-directory case resolves to the CLI default on both flux2 commands and z-image; `--model mlx-community/Z-Image-Turbo-8bit --base-model z-image` resolves to the CFG-capable entry; `black-forest-labs/FLUX.2-klein-9B` still selects klein-9b through the exact match.

## Release note

```release-note
mflux-generate-z-image now honors --base-model for custom checkpoints; family inference reads only the checkpoint's own name, so a parent directory can no longer reshape it; the flux2 guidance error names --base-model as the fix.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model configuration selection for custom checkpoints, preventing misleading parent-directory names from affecting results.
  * Added support for explicitly selecting a base model when resolving compatible checkpoints.
  * Clarified guidance validation errors with instructions for using `--base-model`.
  * Preserved exact repository ID matching for official model entries.

* **Metadata**
  * Exported image metadata now records the resolved base model and supports validation when reused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR hardens restricted model-family resolution and completes Z-Image’s explicit base-model flow.
- Matches official repository IDs before inference and otherwise searches only the checkpoint basename.
- Passes Z-Image’s `--base-model` value into restricted resolution.
- Improves FLUX.2 guidance diagnostics and adds regression coverage for resolution and metadata behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The resolver consistently applies explicit-base precedence, exact allowed repository matching, and basename-only inference across the affected FLUX.2 and Z-Image paths, with focused regression coverage for the changed behavior.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mflux/models/common/resolution/config_resolution.py | Restricts family inference to exact repository IDs or checkpoint basenames while preserving explicit-base precedence. |
| src/mflux/models/z_image/cli/z_image_generate.py | Forwards the parsed base-model declaration so custom Z-Image checkpoints resolve to the requested allowed profile. |
| src/mflux/models/flux2/cli/flux2_generate.py | Clarifies the guidance rejection message without changing validation behavior. |
| src/mflux/models/flux2/cli/flux2_edit_generate.py | Keeps the edit command’s guidance diagnostic aligned with the generation command. |
| tests/test_restricted_model_cli.py | Adds coverage for parent-directory isolation, exact repository matching, Z-Image overrides, and foreign-base rejection. |
| tests/metadata/test_generated_image.py | Verifies that custom-checkpoint metadata stores a replay-valid resolved base model. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI model argument] --> B{Built-in model?}
    B -->|Yes| C[Resolve allowed registry entry]
    B -->|No| D[Custom checkpoint path]
    D --> E{Explicit base model?}
    E -->|Yes| F[Validate and select allowed family entry]
    E -->|No| G{Exact allowed repository ID?}
    G -->|Yes| H[Select exact family entry]
    G -->|No| I[Infer family from basename aliases]
    I -->|No match| J[Use CLI family default]
    C --> K[Initialize model]
    F --> K
    H --> K
    I --> K
    J --> K
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: family inference reads only the che..."](https://github.com/mflux-community/mflux/commit/27d98a7c7860d29ad1e780b2c6ccbaf2925622d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58889624)</sub>

<!-- /greptile_comment -->