### PR TITLE
improvement: cache the ConfigResolution helpers and complete --base-model

### DIFF
--- a/src/mflux/cli/completions/generator.py
+++ b/src/mflux/cli/completions/generator.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from mflux.cli.defaults import defaults as ui_defaults
 from mflux.cli.parser.parsers import CommandLineParser
+from mflux.models.common.resolution.config_resolution import ConfigResolution
 from mflux.models.flux.variants.in_context.utils.in_context_loras import LORA_NAME_MAP
 
 
@@ -153,6 +154,8 @@ class CompletionGenerator:
         # Check for special cases first
         if action.dest == "model":
             return ":model:_mflux_models"
+        elif action.dest == "base_model":
+            return ":base-model:_mflux_base_models"
         elif action.dest == "quantize":
             return ":quantization:_mflux_quantize"
         elif action.dest == "lora_style":
@@ -231,6 +234,16 @@ class CompletionGenerator:
     _values 'model' \\
         {model_choices} \\
         '*:Hugging Face repo:(org/model)'
+}}
+""")
+
+        # Base-model completion helper: canonical keys only, the same short list the
+        # validation error prints. Every alias and repo id (84 spellings) would bury
+        # the useful suggestions, and the resolver accepts the keys everywhere.
+        base_model_choices = " ".join(f"'{k}[{k} base model]'" for k in ConfigResolution.base_model_keys())
+        helpers.append(f"""_mflux_base_models() {{
+    _values 'base model' \\
+        {base_model_choices}
 }}
 """)
 

--- a/src/mflux/models/common/resolution/config_resolution.py
+++ b/src/mflux/models/common/resolution/config_resolution.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from mflux.models.common.resolution.actions import ConfigAction, Rule
@@ -175,27 +176,31 @@ class ConfigResolution:
         raise ValueError(f"No rule matched for model_name: {model_name}")
 
     @staticmethod
-    def base_model_names() -> list[str]:
+    @lru_cache(maxsize=1)
+    def base_model_names() -> tuple[str, ...]:
         # Every value the explicit-base rule accepts: each root config's aliases and its
         # repo id, in priority order. The CLI validates --base-model against this instead
         # of a hand-maintained argparse choices= list, which had drifted far enough to
         # reject names the resolver itself accepts (e.g. `--base-model qwen-image`).
+        # Cached like the defaults.py helpers (AVAILABLE_MODELS is fixed after import),
+        # and a tuple so nobody can mutate the cached value through a reference (#595).
         from mflux.models.common.config.model_config import AVAILABLE_MODELS
 
         names = []
         for config in sorted(AVAILABLE_MODELS.values(), key=lambda m: m.priority):
             if config.base_model is None:
                 names.extend(config.aliases + [config.model_name])
-        return names
+        return tuple(names)
 
     @staticmethod
-    def base_model_keys() -> list[str]:
+    @lru_cache(maxsize=1)
+    def base_model_keys() -> tuple[str, ...]:
         # The canonical key of each root config: the short, printable form of
         # base_model_names(), which is too long to put in an error message once every
         # alias and repo id is spelled out.
         from mflux.models.common.config.model_config import AVAILABLE_MODELS
 
-        return [key for key, config in AVAILABLE_MODELS.items() if config.base_model is None]
+        return tuple(key for key, config in AVAILABLE_MODELS.items() if config.base_model is None)
 
     @staticmethod
     def _check(check: str, ctx: dict) -> bool:
@@ -235,7 +240,7 @@ class ConfigResolution:
         if action == ConfigAction.EXPLICIT_BASE:
             allowed_names = ConfigResolution.base_model_names()
             if base_model not in allowed_names:
-                raise InvalidBaseModel(f"Invalid base_model. Choose one of {allowed_names}")
+                raise InvalidBaseModel(f"Invalid base_model. Choose one of {list(allowed_names)}")
 
             default_base = next(
                 (b for b in base_models if base_model == b.model_name or base_model in b.aliases),

--- a/tests/arg_parser/test_model_choices.py
+++ b/tests/arg_parser/test_model_choices.py
@@ -83,3 +83,14 @@ def test_base_model_validation_matches_the_resolver():
         if config.base_model is None:
             assert key in allowed, key
             assert all(alias in allowed for alias in config.aliases), key
+
+
+@pytest.mark.fast
+def test_registry_helpers_are_cached_and_immutable():
+    # The defaults.py helpers cache their registry-derived lists; the ConfigResolution
+    # siblings rebuilt theirs on every call (#595). Same-object across calls proves the
+    # cache; tuples keep a caller from mutating the value everyone else then sees.
+    assert ConfigResolution.base_model_names() is ConfigResolution.base_model_names()
+    assert ConfigResolution.base_model_keys() is ConfigResolution.base_model_keys()
+    assert isinstance(ConfigResolution.base_model_names(), tuple)
+    assert isinstance(ConfigResolution.base_model_keys(), tuple)

--- a/tests/cli/test_completion_generator.py
+++ b/tests/cli/test_completion_generator.py
@@ -101,3 +101,25 @@ def test_completion_generator_prefers_the_cli_own_parser():
     )
     assert "_mflux_generate_lens()" in script
     assert "--prompt" in script
+
+
+@pytest.mark.fast
+def test_completion_generator_completes_base_model():
+    # --base-model lost its completions when #592 dropped the (stale) argparse choices=
+    # list; the flag must route to a helper fed from the resolver instead (#595).
+    generator = CompletionGenerator()
+    parser = generator.create_parser_for_command("mflux-generate")
+    script = generator.generate_command_function("mflux-generate", parser)
+
+    assert "_mflux_base_models" in script
+
+    helpers = generator.generate_helper_functions()
+    assert "_mflux_base_models()" in helpers
+    # The canonical keys, and only them: every alias plus repo id would bury the
+    # useful suggestions (base_model_names() is ~84 entries).
+    helper_body = helpers.split("_mflux_base_models() {", 1)[1].split("}", 1)[0]
+    from mflux.models.common.resolution.config_resolution import ConfigResolution
+
+    for key in ConfigResolution.base_model_keys():
+        assert f"'{key}[" in helper_body, key
+    assert "black-forest-labs" not in helper_body


### PR DESCRIPTION
Closes #595, both checkboxes.

**1. Cache the `ConfigResolution` helpers.** `base_model_names()` and `base_model_keys()` now sit behind `@lru_cache(maxsize=1)` like their `defaults.py` siblings, and return tuples so the cached value cannot be mutated through a reference. `AVAILABLE_MODELS` is fixed after import, so `maxsize=1` is safe, as the issue laid out. The `InvalidBaseModel` message wraps the tuple in `list()` so the printed error keeps its shape.

**2. Complete `--base-model`.** The generator routes `dest == "base_model"` to a new `_mflux_base_models` zsh helper fed from `base_model_keys()`: the canonical keys only, the same short list the validation error prints. All 84 spellings (aliases plus repo ids) would bury the useful suggestions.

Ran: full fast suite locally (1424 passed), plus a manual `generate_helper_functions()` dump checking the emitted helper lists exactly the 34 canonical keys and `--base-model` carries `:base-model:_mflux_base_models`.

```release-note
Shell completion now suggests --base-model values (the canonical model names).
```


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR caches immutable base-model resolution helper results and adds canonical `--base-model` suggestions to generated Zsh completion.

- Converts registry-derived base-model helper results to cached tuples.
- Adds a dedicated `_mflux_base_models` completion helper.
- Adds tests for caching, immutability, and completion output.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The cached helper results remain compatible with all callers and the generated completion values are accepted canonical keys with valid Zsh syntax.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mflux/cli/completions/generator.py | Adds parser routing and a generated Zsh helper for canonical base-model values without introducing an invalid completion path. |
| src/mflux/models/common/resolution/config_resolution.py | Caches immutable registry-derived tuples while preserving validation behavior and caller compatibility. |
| tests/arg_parser/test_model_choices.py | Verifies helper identity caching and immutable tuple return types. |
| tests/cli/test_completion_generator.py | Verifies base-model option routing and canonical completion entries. |

</details>

<sub>Reviews (1): Last reviewed commit: ["improvement: the ConfigResolution helper..."](https://github.com/mflux-community/mflux/commit/f9487932af434cabb86692fa10c7eaa9cce7a5bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59440232)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell completion support for the `--base-model` option.
  * Completion suggestions now include the available canonical base model keys.

* **Bug Fixes**
  * Improved invalid base model error messages by clearly listing supported options.
  * Base model choices are now consistently reused, improving response efficiency and preventing accidental modification of available options.

* **Tests**
  * Added coverage to verify base model completion and consistent, immutable model choice results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->