### PR TITLE
fix: the sidecar records the weights source, and -C replays from it

### DIFF
--- a/src/mflux/cli/parser/parsers.py
+++ b/src/mflux/cli/parser/parsers.py
@@ -418,9 +418,13 @@ class CommandLineParser(argparse.ArgumentParser):
             prior_gen_metadata = json.load(namespace.config_from_metadata.open("rt"))
 
             if hasattr(namespace, "model") and not self._option_was_provided("--model", "-m"):
-                # When --model was not provided explicitly, metadata should win
-                # even if the parser set a command-specific default model.
-                namespace.model = prior_gen_metadata.get("model", namespace.model)
+                # When --model was not provided explicitly, metadata should win even if the
+                # parser set a command-specific default model. A run whose weights came from
+                # a path or third-party repo records that source in model_path, and the
+                # source is what the command line actually said, so it wins over the
+                # resolved registry entry in "model" (#705); older sidecars carry only the
+                # entry and restore as before.
+                namespace.model = prior_gen_metadata.get("model_path") or prior_gen_metadata.get("model", namespace.model)
 
             if namespace.base_model is None:
                 # Sidecars written before #695 store the literal string "None" for a builtin
@@ -636,5 +640,12 @@ class CommandLineParser(argparse.ArgumentParser):
             namespace.model_path = None if namespace.model in ui_defaults.model_choices() else namespace.model
         else:
             namespace.model_path = None
+
+        # Hand the weights source to the sidecar writer (#705). GeneratedImage cannot see
+        # the namespace, so this travels the way --no-metadata reaches ImageUtil; set on
+        # every parse so one run's path cannot leak into the next.
+        from mflux.utils.generated_image import GeneratedImage
+
+        GeneratedImage.model_path = namespace.model_path
 
         return namespace

--- a/src/mflux/cli/parser/parsers.py
+++ b/src/mflux/cli/parser/parsers.py
@@ -417,6 +417,7 @@ class CommandLineParser(argparse.ArgumentParser):
         if getattr(namespace, "config_from_metadata", False):
             prior_gen_metadata = json.load(namespace.config_from_metadata.open("rt"))
 
+            restored_weights_source = None
             if hasattr(namespace, "model") and not self._option_was_provided("--model", "-m"):
                 # When --model was not provided explicitly, metadata should win even if the
                 # parser set a command-specific default model. A run whose weights came from
@@ -424,13 +425,22 @@ class CommandLineParser(argparse.ArgumentParser):
                 # source is what the command line actually said, so it wins over the
                 # resolved registry entry in "model" (#705); older sidecars carry only the
                 # entry and restore as before.
-                namespace.model = prior_gen_metadata.get("model_path") or prior_gen_metadata.get("model", namespace.model)
+                restored_weights_source = prior_gen_metadata.get("model_path")
+                namespace.model = restored_weights_source or prior_gen_metadata.get("model", namespace.model)
 
             if namespace.base_model is None:
                 # Sidecars written before #695 store the literal string "None" for a builtin
                 # run; it means the same as the null they store now, and handing it to the
                 # --base-model validator below would reject the replay.
                 restored_base_model = prior_gen_metadata.get("base_model", None)
+                if restored_base_model in (None, "None") and restored_weights_source is not None:
+                    # A restored weights source alone would erase the run's family: a
+                    # restricted CLI of another family would pair the foreign weights with
+                    # its default geometry instead of rejecting them the way it rejects the
+                    # entry by name. The entry the run resolved to rides along as the
+                    # explicit base, which keeps that rejection and pins the exact entry on
+                    # the right CLI without re-inferring it from the basename.
+                    restored_base_model = prior_gen_metadata.get("model", None)
                 if restored_base_model not in (None, "None"):
                     namespace.base_model = restored_base_model
 

--- a/src/mflux/utils/generated_image.py
+++ b/src/mflux/utils/generated_image.py
@@ -14,6 +14,13 @@ log = logging.getLogger(__name__)
 
 
 class GeneratedImage:
+    # The weights source of the current CLI run: the --model value when it named a path or
+    # third-party repo rather than a registry entry, None otherwise. Set by
+    # CommandLineParser.parse_args the way --no-metadata reaches ImageUtil: the parser is
+    # the only place that knows it, and threading it through every variant's to_image call
+    # would touch thirty call sites to move one provenance string (#705).
+    model_path: str | None = None
+
     def __init__(
         self,
         image: PIL.Image.Image,
@@ -221,6 +228,9 @@ class GeneratedImage:
         metadata = {
             "mflux_version": VersionUtil.get_mflux_version(),
             "model": self.model_config.model_name,
+            # Without the source, a local-checkpoint run reads back as the registry entry
+            # it resolved to, and -C silently replays it against the registry weights (#705).
+            "model_path": self.model_path,
             # The value itself, not str() of it: a builtin run has no base and must store null,
             # because --config-from-metadata hands this back to the --base-model validator and
             # the string "None" is not a name (#695).

--- a/tests/arg_parser/test_metadata_roundtrip_restore.py
+++ b/tests/arg_parser/test_metadata_roundtrip_restore.py
@@ -8,11 +8,13 @@ import sys
 
 import pytest
 
+from mflux.models.common.resolution.config_resolution import ConfigResolution
 from mflux.models.flux.cli import flux_generate_redux
 from mflux.models.flux2.cli import flux2_edit_generate, flux2_generate
 from mflux.models.krea2.cli import krea2_generate
 from mflux.models.qwen.cli import qwen_image_edit_generate
 from mflux.models.z_image.cli import z_image_generate
+from mflux.utils.exceptions import ModelConfigError
 
 ELSEWHERE = "/Users/someone-else/photos/cat.png"
 
@@ -261,3 +263,45 @@ def test_a_sidecar_without_a_weights_source_restores_the_entry(parse, sidecar):
     args = parse(krea2_generate, "--config-from-metadata", str(prior))
     assert args.model == "krea-2"
     assert args.model_path is None
+
+
+@pytest.mark.fast
+def test_the_recorded_entry_rides_along_as_the_base(parse, sidecar):
+    # The weights source alone erases the run's family. The entry it resolved to comes
+    # back as the explicit base, so the right CLI pins the exact entry without
+    # re-inferring it from the basename (#708 review).
+    prior = sidecar(model="black-forest-labs/FLUX.2-klein-4B", model_path="/models/my-finetune", image_paths=None)
+    args = parse(flux2_generate, "--config-from-metadata", str(prior))
+    assert args.base_model == "black-forest-labs/FLUX.2-klein-4B"
+    resolved = ConfigResolution.resolve_restricted(
+        args.model,
+        "flux2-klein-4b",
+        model_path=args.model_path,
+        base_model=args.base_model,
+        extra_keys=("flux2-klein-9b", "flux2-klein-base-4b", "flux2-klein-base-9b", "flux2-klein-9b-kv"),
+    )
+    assert resolved.model_name == "black-forest-labs/FLUX.2-klein-4B"
+
+
+@pytest.mark.fast
+def test_a_cross_family_replay_is_still_rejected(parse, sidecar):
+    # Replaying a flux2 checkpoint sidecar through the z-image command used to die inside
+    # weight loading on the default entry's geometry once the source was preferred; the
+    # ride-along base restores the clean rejection the entry produced by name.
+    prior = sidecar(model="black-forest-labs/FLUX.2-klein-4B", model_path="/models/klein-4b-q4", image_paths=None)
+    args = parse(z_image_generate, "--config-from-metadata", str(prior))
+    with pytest.raises(ModelConfigError):
+        ConfigResolution.resolve_restricted(
+            args.model,
+            "z-image",
+            model_path=args.model_path,
+            base_model=args.base_model,
+            extra_keys=("z-image-turbo",),
+        )
+
+
+@pytest.mark.fast
+def test_an_explicit_base_model_beats_the_ride_along(parse, sidecar):
+    prior = sidecar(model="black-forest-labs/FLUX.2-klein-4B", model_path="/models/my-finetune", image_paths=None)
+    args = parse(flux2_generate, "--base-model", "flux2-klein-base-4b", "--config-from-metadata", str(prior))
+    assert args.base_model == "flux2-klein-base-4b"

--- a/tests/arg_parser/test_metadata_roundtrip_restore.py
+++ b/tests/arg_parser/test_metadata_roundtrip_restore.py
@@ -9,7 +9,7 @@ import sys
 import pytest
 
 from mflux.models.flux.cli import flux_generate_redux
-from mflux.models.flux2.cli import flux2_edit_generate
+from mflux.models.flux2.cli import flux2_edit_generate, flux2_generate
 from mflux.models.krea2.cli import krea2_generate
 from mflux.models.qwen.cli import qwen_image_edit_generate
 from mflux.models.z_image.cli import z_image_generate
@@ -225,3 +225,39 @@ def test_an_old_repr_redux_sidecar_is_not_treated_as_paths(parse, sidecar, capsy
         parse(flux_generate_redux, "--config-from-metadata", str(path))
     assert exit_info.value.code == 2
     assert "--redux-image-paths" in capsys.readouterr().err
+
+
+# A local-checkpoint run stores the registry entry it resolved to in "model" and the
+# actual weights source in "model_path". Restoring the entry alone replays against the
+# registry weights with no error, which is #705: the source is what the command line
+# actually said, so it wins. Pre-#705 sidecars carry no model_path and restore as before.
+@pytest.mark.fast
+def test_the_sidecar_replays_the_weights_source_it_ran_from(parse, sidecar):
+    prior = sidecar(
+        model="black-forest-labs/FLUX.2-klein-4B",
+        model_path="/models/klein-4b-q4",
+        image_paths=None,
+    )
+    args = parse(flux2_generate, "--config-from-metadata", str(prior))
+    assert args.model == "/models/klein-4b-q4"
+    assert args.model_path == "/models/klein-4b-q4"
+
+
+@pytest.mark.fast
+def test_an_explicit_model_beats_the_sidecar_weights_source(parse, sidecar):
+    prior = sidecar(
+        model="black-forest-labs/FLUX.2-klein-4B",
+        model_path="/models/klein-4b-q4",
+        image_paths=None,
+    )
+    args = parse(flux2_generate, "--model", "flux2-klein-4b", "--config-from-metadata", str(prior))
+    assert args.model == "flux2-klein-4b"
+    assert args.model_path is None
+
+
+@pytest.mark.fast
+def test_a_sidecar_without_a_weights_source_restores_the_entry(parse, sidecar):
+    prior = sidecar()  # the fixture's krea-2 sidecar, as written before #705
+    args = parse(krea2_generate, "--config-from-metadata", str(prior))
+    assert args.model == "krea-2"
+    assert args.model_path is None

--- a/tests/metadata/test_generated_image.py
+++ b/tests/metadata/test_generated_image.py
@@ -1,6 +1,7 @@
 import json
 
 import mlx.core as mx
+import pytest
 from PIL import Image
 
 from mflux.models.common.config import ModelConfig
@@ -62,6 +63,16 @@ def test_exported_metadata_uses_metadata_sidecar_suffix(tmp_path):
     assert json.loads(metadata_path.read_text())["seed"] == 42
 
 
+@pytest.fixture(autouse=True)
+def _reset_run_model_path():
+    # GeneratedImage.model_path is per-run state set by CommandLineParser.parse_args;
+    # arg-parser tests in the same session parse custom checkpoints and would leak
+    # their path into the writers built directly here.
+    GeneratedImage.model_path = None
+    yield
+    GeneratedImage.model_path = None
+
+
 def test_builtin_run_stores_null_base_model(tmp_path):
     # str(None) used to land here as the string "None", which --config-from-metadata then
     # fed to the --base-model validator (#695). A builtin run stores null; a custom
@@ -86,6 +97,7 @@ def test_builtin_run_stores_null_base_model(tmp_path):
     stored = json.loads(output_path.with_suffix(".metadata.json").read_text())
     assert stored["base_model"] is None
     assert stored["model"] == ModelConfig.dev().model_name
+    assert stored["model_path"] is None
 
 
 def test_pid_decode_and_resize_round_trip_through_metadata(tmp_path):
@@ -300,3 +312,30 @@ def test_custom_checkpoint_stores_the_base_it_resolved_to(tmp_path):
     stored = json.loads(output_path.with_suffix(".metadata.json").read_text())
     assert stored["base_model"] == "black-forest-labs/FLUX.1-dev"
     assert stored["base_model"] in ConfigResolution.base_model_names()
+
+
+def test_the_sidecar_records_the_weights_source_of_the_run(tmp_path):
+    # A local-checkpoint run resolves to a registry entry, and "model" stores that entry:
+    # without the source path next to it the run reads back as the builtin and -C replays
+    # it against the registry weights (#705). The parser sets this per run; unset (a
+    # library caller, or a builtin run) stores null.
+    output_path = tmp_path / "generated.png"
+    GeneratedImage.model_path = "/models/klein-4b-q4"
+    generated_image = GeneratedImage(
+        image=Image.new("RGB", (16, 16), "white"),
+        model_config=ModelConfig.dev(),
+        seed=42,
+        prompt="test prompt",
+        steps=20,
+        guidance=3.5,
+        precision=mx.bfloat16,
+        quantization=8,
+        generation_time=1.23,
+        height=16,
+        width=16,
+    )
+
+    generated_image.save(path=output_path, overwrite=True, export_json_metadata=True)
+
+    stored = json.loads(output_path.with_suffix(".metadata.json").read_text())
+    assert stored["model_path"] == "/models/klein-4b-q4"


### PR DESCRIPTION
Fixes #705.

The sidecar of a `--model <local dir or third-party repo>` run stored only the registry entry the checkpoint resolved to, so `-C` silently replayed it against the registry weights. Three changes, one per layer:

- **Writer**: the sidecar records `model_path` next to `model`. The path travels from the parser to `GeneratedImage` as a class attribute set on every parse, the same way `--no-metadata` reaches `ImageUtil.embed_metadata_enabled`; threading it through every variant's `to_image` call would touch thirty call sites to move one provenance string.
- **Restore**: `-C` prefers `model_path` over `model` because the source is what the command line actually said. An explicit `--model` still wins, and pre-#705 sidecars (no `model_path` key) restore exactly as before.
- **Failure mode**: a recorded path that no longer exists now fails loudly (`Model not found: ...`) instead of substituting the registry weights.

Ran: full fast suite locally (1425 passed), plus the issue's repro end-to-end on the M5 with a q4-saved klein-4b: the new sidecar carries the path, replay loads from the dir (peak 5.08 GB vs 10.5 pre-fix, pixels identical to the original run), and replay with the dir renamed away dies with `FileNotFoundError` naming the path.

```release-note
The metadata sidecar now records the checkpoint path a run used, and --config-from-metadata replays from it instead of silently substituting the built-in model's weights.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Generation metadata now records the actual weights source, including local checkpoints and external repositories.
  - Replaying a generation restores the recorded weights source when no model is explicitly selected.

- **Bug Fixes**
  - Older metadata without a recorded weights source continues to restore using the registered model.
  - Explicit model selections take precedence over metadata during replay.
  - Cross-family model replays are rejected cleanly when the recorded source is incompatible.

- **Tests**
  - Added coverage for weights-source recording, metadata replay, legacy metadata, model-family validation, and explicit model overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR records custom checkpoint provenance in generated-image sidecars and makes metadata replay prefer that source while preserving explicit command-line model precedence.
- Adds `model_path` to generated metadata.
- Publishes the parsed weights source to the metadata writer.
- Adds writer and replay regression tests for custom, explicit, and legacy model selection.
</details>


<h3>Confidence Score: 4/5</h3>

The cross-family metadata replay path should be fixed before merging because it can replace a clear family error with incompatible model geometry and weights.

Preferring the raw checkpoint path discards the sidecar's resolved-family signal before restricted resolution, allowing a sidecar from another family to load its weights under the replay command's default configuration.

**Files Needing Attention:** src/mflux/cli/parser/parsers.py

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mflux/cli/parser/parsers.py | Restores and republishes checkpoint provenance correctly for same-command replay, but preferring the raw path can bypass foreign-family rejection during cross-command replay. |
| src/mflux/utils/generated_image.py | Adds the parsed checkpoint source to JSON metadata through process-global class state; no independently publishable failure was established in shipped command lifecycles. |
| tests/arg_parser/test_metadata_roundtrip_restore.py | Covers same-command source replay, explicit-model precedence, and legacy sidecars, but not replay through a different restricted model-family command. |
| tests/metadata/test_generated_image.py | Verifies null provenance for built-ins and the expected source value for custom-checkpoint metadata. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[CLI --model] --> B[Parser classification]
  B --> C[GeneratedImage.model_path]
  C --> D[Metadata sidecar]
  D --> E[-C metadata restore]
  E --> F{Explicit --model?}
  F -->|Yes| G[Use explicit model]
  F -->|No| H[Prefer recorded model_path]
  H --> I[Resolve model configuration]
  H --> J[Load recorded weights]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20mflux-community%2Fmflux%20PR%20%23708%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=mflux-community%2Fmflux&pr=708&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fmflux%2Fcli%2Fparser%2Fparsers.py%3A427%0A**Cross-family%20replay%20bypasses%20rejection**%0A%0AWhen%20a%20custom-checkpoint%20sidecar%20from%20one%20model%20family%20is%20replayed%20with%20a%20different%20restricted%20command%2C%20preferring%20%60model_path%60%20discards%20the%20recorded%20model-family%20identity.%20The%20restricted%20resolver%20then%20pairs%20those%20weights%20with%20its%20default%20geometry%2C%20causing%20a%20loading%20or%20attention%20reshape%20failure%20instead%20of%20rejecting%20the%20foreign%20model.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mflux-community%2Fmflux&pr=708&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/mflux/cli/parser/parsers.py:427
**Cross-family replay bypasses rejection**

When a custom-checkpoint sidecar from one model family is replayed with a different restricted command, preferring `model_path` discards the recorded model-family identity. The restricted resolver then pairs those weights with its default geometry, causing a loading or attention reshape failure instead of rejecting the foreign model.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: the sidecar records the weights sou..."](https://github.com/mflux-community/mflux/commit/19fe8f252abe65e7ff1d1ddaf6db825e7fefaf8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59755259)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Command-line interface](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/command-line-interface.md)
- Knowledge Base — [CLI parser and capabilities](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/cli-parser-and-capabilities.md)

<!-- /greptile_comment -->