### PR TITLE
feat: opt-in gradient_checkpointing for training, with the backward evaluated last-block-first

### DIFF
--- a/src/mflux/models/common/README.md
+++ b/src/mflux/models/common/README.md
@@ -308,6 +308,7 @@ FLUX.1 uses `mflux-generate` with `--model dev` (or `schnell` / `krea-dev`) and 
 - Training supports normal (txt2img) and edit modes; the mode is auto-detected from your data folder layout (see examples below).
 - Expected layout: a config file plus a data folder with images and optional prompt files.
 - **Edit mode limitation**: Edit training currently supports only FLUX.2-klein-base models (`flux2-klein-base-4b` or `flux2-klein-base-9b`).
+- **Memory**: `"gradient_checkpointing": true` recomputes each transformer block's activations during the backward pass instead of keeping all of them, and evaluates the gradients last-block-first (the evaluation order matters in MLX; in tree order the recomputed blocks all stay alive and the saving disappears). Steps get ~30% slower and peak memory drops to roughly "weights + a couple of blocks". Turn it on when a run is killed at the first training step; it is what makes FLUX.2 klein edit training fit on 32–36 GB machines. Combine with `"quantize": 8` and `"low_ram": true` on the tightest machines.
 - To train a local copy of a model, you can specify the path to that model in the training spec JSON alongside the `model` using the `model_path` key.
 - For model-specific config fields, see the [Z-Image README](../z_image/README.md) and [FLUX.2 README](../flux2/README.md).
 

--- a/src/mflux/models/common/training/adapters/base.py
+++ b/src/mflux/models/common/training/adapters/base.py
@@ -20,6 +20,8 @@ class TrainingAdapter(Protocol):
 
     def freeze_base(self) -> None: ...
 
+    def set_gradient_checkpointing(self, enabled: bool) -> None: ...
+
     def encode_data(
         self,
         *,

--- a/src/mflux/models/common/training/state/training_spec.py
+++ b/src/mflux/models/common/training/state/training_spec.py
@@ -260,6 +260,11 @@ class TrainingSpec:
     # to hold the largest transient allocations seen; bounding it returns freed buffers to
     # the OS at ~no speed cost (unlike low_ram's clear-every-step). None = MLX default.
     cache_limit_gb: float | None = None
+    # Recompute each transformer block's activations in the backward pass instead of keeping
+    # them, and evaluate the gradients last-block-first. Trades ~30% step time for a peak
+    # memory of roughly "weights + two blocks" instead of "weights + every block"; this is what
+    # makes edit training fit on 32-36 GB machines.
+    gradient_checkpointing: bool = False
 
     @staticmethod
     def resolve(
@@ -317,6 +322,8 @@ class TrainingSpec:
         low_ram = bool(config.get("low_ram", False))
         if low_ram and data_root_dir is None:
             raise ValueError("'low_ram' requires a valid data path.")
+
+        gradient_checkpointing = bool(config.get("gradient_checkpointing", False))
 
         cache_limit_raw = config.get("cache_limit_gb", None)
         cache_limit_gb = None if cache_limit_raw is None else float(cache_limit_raw)
@@ -462,6 +469,7 @@ class TrainingSpec:
             config_path=None if absolute_config_path is None else str(absolute_config_path),
             low_ram=low_ram,
             cache_limit_gb=cache_limit_gb,
+            gradient_checkpointing=gradient_checkpointing,
         )
 
     @staticmethod

--- a/src/mflux/models/common/training/trainer.py
+++ b/src/mflux/models/common/training/trainer.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import gc
 import random
+import re
 import tempfile
 from pathlib import Path
 
 import mlx.core as mx
 from mlx import nn
 from mlx.optimizers import clip_grad_norm
-from mlx.utils import tree_map, tree_unflatten
+from mlx.utils import tree_flatten, tree_map, tree_unflatten
 from tqdm import tqdm
 
 from mflux.models.common.latent_creator.latent_creator import LatentCreator
@@ -24,6 +25,10 @@ from mflux.utils.exif_orientation import oriented_size
 
 
 class TrainingTrainer:
+    # Path prefix up to and including the first numeric segment, e.g.
+    # "transformer.single_transformer_blocks.7" from "...single_transformer_blocks.7.attn.to_out.lora_A".
+    _BLOCK_PREFIX = re.compile(r"^(.*?\.\d+)(?:\.|$)")
+
     @staticmethod
     def _sample_timestep_index(timestep_type: str, low: int, high: int, rng) -> int:
         # Map a [0,1) draw shaped by the distribution to a timestep index in [low, high).
@@ -141,6 +146,10 @@ class TrainingTrainer:
         # Freeze base weights and unfreeze LoRA weights
         adapter.freeze_base()
         TrainingTrainer._unfreeze_lora_layers(adapter.transformer())
+        if training_spec.gradient_checkpointing:
+            adapter.set_gradient_checkpointing(True)
+        # Krea 2 forces checkpointing on in freeze_base, so read the effective state back.
+        gradient_checkpointing = bool(getattr(adapter.transformer(), "gradient_checkpointing", False))
 
         train_step_function = nn.value_and_grad(
             model=adapter.model(),
@@ -169,6 +178,8 @@ class TrainingTrainer:
         nonfinite_skips = 0
         for batch in batches:
             loss, grads = train_step_function(batch)
+            if gradient_checkpointing:
+                TrainingTrainer._evaluate_backward_in_block_order(loss, grads)
             if not TrainingTrainer._step_is_finite(loss):
                 del loss, grads
                 nonfinite_skips += 1
@@ -228,6 +239,22 @@ class TrainingTrainer:
         if nonfinite_skips:
             print(f"Skipped {nonfinite_skips} non-finite (NaN/Inf) training step(s).")
         training_state.save(adapter, training_spec)
+
+    @staticmethod
+    def _evaluate_backward_in_block_order(loss: mx.array, grads) -> None:
+        # MLX is lazy, so the order the gradients are evaluated in decides how many recomputed
+        # block activations are alive at once. Evaluating them first-block-first (tree order)
+        # forces every later block to be recomputed and kept until its own gradient is collected,
+        # which silently undoes gradient checkpointing (peak memory ends up the same as without
+        # it). Evaluate the forward, then walk the blocks from the last one backwards so only a
+        # couple of blocks' activations exist at any time.
+        mx.eval(loss)
+        groups: dict[str, list[mx.array]] = {}
+        for path, grad in tree_flatten(grads):
+            block_prefix = TrainingTrainer._BLOCK_PREFIX.match(path)
+            groups.setdefault(block_prefix.group(1) if block_prefix else "", []).append(grad)
+        for key in reversed(list(groups)):
+            mx.eval(*groups[key])
 
     @staticmethod
     def _unfreeze_lora_layers(module: nn.Module) -> None:

--- a/src/mflux/models/ernie_image/model/ernie_transformer/transformer.py
+++ b/src/mflux/models/ernie_image/model/ernie_transformer/transformer.py
@@ -152,8 +152,11 @@ class ErnieTransformer(nn.Module):
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = [p[:, None, :] for p in pieces]
         temb = (shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp)
 
+        # Optional gradient checkpointing (see Krea2Transformer); the training adapter turns it on.
+        gradient_checkpointing = getattr(self, "gradient_checkpointing", False)
         for layer in self.layers:
-            x = layer(x, cos, sin, temb, attn_mask)
+            run = nn.utils.checkpoint(layer) if gradient_checkpointing else layer
+            x = run(x, cos, sin, temb, attn_mask)
 
         img_tokens = x[:, :N_img, :]
         img_tokens = self.final_norm(img_tokens, c).astype(hidden_states.dtype)

--- a/src/mflux/models/ernie_image/training_adapter/ernie_training_adapter.py
+++ b/src/mflux/models/ernie_image/training_adapter/ernie_training_adapter.py
@@ -51,6 +51,9 @@ class ErnieTrainingAdapter(TrainingAdapter):
         self._ernie.transformer.freeze()
         self._ernie.text_encoder.freeze()
 
+    def set_gradient_checkpointing(self, enabled: bool) -> None:
+        self._ernie.transformer.gradient_checkpointing = enabled
+
     def encode_data(
         self,
         *,

--- a/src/mflux/models/flux2/README.md
+++ b/src/mflux/models/flux2/README.md
@@ -131,6 +131,7 @@ Example (base model defaults to 50 steps):
   "guidance": 1.0,
   "quantize": null,
   "low_ram": false,
+  "gradient_checkpointing": false,
   "max_resolution": 1024,
   "training_loop": { "num_epochs": 100, "batch_size": 1, "timestep_low": 25, "timestep_high": 40 },
   "optimizer": { "name": "AdamW", "learning_rate": 1e-4 },
@@ -165,6 +166,9 @@ Run training:
 ```sh
 mflux-train --config /path/to/train.json
 ```
+
+> [!TIP]
+> On a 32–36 GB Mac, set `"gradient_checkpointing": true` (and `"quantize": 8`); without it the first training step of an edit run needs more memory than the machine has and the process is killed. See the common [training docs](../common/README.md#training-lora).
 
 ### Edit fine-tuning (image-conditioned)
  The config looks identical for edit-based training and only differs in how the training data is prepared and named. For edit-style training (image in + prompt → image out), use auto-discovery with paired `*_out.*` and `*_in.*` files plus `*_in.txt` prompts, see the [training docs](../common/README.md#training-lora) for examples. Edit training is supported for Flux2 Klein base models. Preview prompts come from `data/preview*.txt` and the preview images are `data/preview*.{png,jpg,jpeg,webp}`.

--- a/src/mflux/models/flux2/model/flux2_transformer/transformer.py
+++ b/src/mflux/models/flux2/model/flux2_transformer/transformer.py
@@ -125,8 +125,13 @@ class Flux2Transformer(nn.Module):
                 for mod_params, ref_mod_params in zip(temb_mod_params_img, ref_temb_mod_params_img, strict=True)
             )
 
+        # Optional gradient checkpointing (see Krea2Transformer): recompute each block in the
+        # backward pass instead of storing its activations. Off by default so inference is
+        # unaffected; the training adapter turns it on from the training config.
+        gradient_checkpointing = getattr(self, "gradient_checkpointing", False)
         for idx, block in enumerate(self.transformer_blocks):
-            encoder_hidden_states, hidden_states = block(
+            run = nn.utils.checkpoint(block) if gradient_checkpointing else block
+            encoder_hidden_states, hidden_states = run(
                 hidden_states=hidden_states,
                 encoder_hidden_states=encoder_hidden_states,
                 temb_mod_params_img=temb_mod_params_img,
@@ -148,7 +153,8 @@ class Flux2Transformer(nn.Module):
                 num_ref_tokens=kv_cache.num_ref_tokens,
             )
         for idx, block in enumerate(self.single_transformer_blocks):
-            hidden_states = block(
+            run = nn.utils.checkpoint(block) if gradient_checkpointing else block
+            hidden_states = run(
                 hidden_states=hidden_states,
                 temb_mod_params=temb_mod_params_single,
                 image_rotary_emb=concat_rotary_emb,

--- a/src/mflux/models/flux2/training_adapter/flux2_base_training_adapter.py
+++ b/src/mflux/models/flux2/training_adapter/flux2_base_training_adapter.py
@@ -53,6 +53,9 @@ class Flux2BaseTrainingAdapter(TrainingAdapter):
         self._flux2.transformer.freeze()
         self._flux2.text_encoder.freeze()
 
+    def set_gradient_checkpointing(self, enabled: bool) -> None:
+        self._flux2.transformer.gradient_checkpointing = enabled
+
     def _encode_output_latents(self, *, image_path: Path, width: int, height: int) -> tuple[mx.array, mx.array]:
         encoded = LatentCreator.encode_image(
             vae=self._flux2.vae,

--- a/src/mflux/models/krea2/training_adapter/krea2_training_adapter.py
+++ b/src/mflux/models/krea2/training_adapter/krea2_training_adapter.py
@@ -62,6 +62,10 @@ class Krea2TrainingAdapter(TrainingAdapter):
         # transformer's activation graph fits in memory. Only the LoRA matrices are trainable.
         self._krea2.transformer.gradient_checkpointing = True
 
+    def set_gradient_checkpointing(self, enabled: bool) -> None:  # noqa: ARG002
+        # Always on for Krea 2 (see freeze_base); the config flag cannot turn it off.
+        self._krea2.transformer.gradient_checkpointing = True
+
     def encode_data(
         self,
         *,

--- a/src/mflux/models/z_image/model/z_image_transformer/transformer.py
+++ b/src/mflux/models/z_image/model/z_image_transformer/transformer.py
@@ -122,8 +122,11 @@ class ZImageTransformer(nn.Module):
         unified_freqs_cis = mx.concatenate([x_freqs_cis, cap_freqs_cis], axis=0)
         unified_attn_mask = mx.ones((1, unified.shape[1]), dtype=mx.bool_)
 
+        # Optional gradient checkpointing (see Krea2Transformer); the training adapter turns it on.
+        gradient_checkpointing = getattr(self, "gradient_checkpointing", False)
         for layer_idx, layer in enumerate(self.layers):
-            unified = layer(
+            run = nn.utils.checkpoint(layer) if gradient_checkpointing else layer
+            unified = run(
                 x=unified,
                 attn_mask=unified_attn_mask,
                 freqs_cis=unified_freqs_cis,

--- a/src/mflux/models/z_image/training_adapter/z_image_training_adapter.py
+++ b/src/mflux/models/z_image/training_adapter/z_image_training_adapter.py
@@ -47,6 +47,9 @@ class ZImageTrainingAdapter(TrainingAdapter):
         self._z.transformer.freeze()
         self._z.text_encoder.freeze()
 
+    def set_gradient_checkpointing(self, enabled: bool) -> None:
+        self._z.transformer.gradient_checkpointing = enabled
+
     def encode_data(
         self,
         *,

--- a/tests/training/test_gradient_checkpointing.py
+++ b/tests/training/test_gradient_checkpointing.py
@@ -54,6 +54,20 @@ class _TinyFlux2:
         return model.transformer(**inputs).square().mean()
 
     @staticmethod
+    def run(model: nn.Module, inputs: dict, *, checkpointing: bool, ordered: bool) -> tuple[float, dict, int]:
+        # One value-and-grad step: the loss, the gradients flattened by parameter path, and the
+        # peak memory the step reached.
+        model.transformer.gradient_checkpointing = checkpointing
+        mx.reset_peak_memory()
+        value_and_grad = nn.value_and_grad(model, lambda m, i: _TinyFlux2.loss(m, i))
+        loss, grads = value_and_grad(model, inputs)
+        if ordered:
+            TrainingTrainer._evaluate_backward_in_block_order(loss, grads)
+        else:
+            mx.eval(loss, grads)
+        return float(loss), dict(tree_flatten(grads)), mx.get_peak_memory()
+
+    @staticmethod
     def _inject_lora(module: nn.Module) -> None:
         for key, value in list(module.items()):
             if isinstance(value, nn.Linear) and not isinstance(value, LoRALinear):
@@ -66,30 +80,20 @@ class _TinyFlux2:
                         _TinyFlux2._inject_lora(item)
 
 
-def _run(model: nn.Module, inputs: dict, *, checkpointing: bool, ordered: bool) -> tuple[float, float, int]:
-    model.transformer.gradient_checkpointing = checkpointing
-    mx.reset_peak_memory()
-    value_and_grad = nn.value_and_grad(model, lambda m, i: _TinyFlux2.loss(m, i))
-    loss, grads = value_and_grad(model, inputs)
-    if ordered:
-        TrainingTrainer._evaluate_backward_in_block_order(loss, grads)
-    else:
-        mx.eval(loss, grads)
-    flat = tree_flatten(grads)
-    grad_norm = float(mx.sqrt(sum((g.astype(mx.float32) ** 2).sum() for _, g in flat)))
-    return float(loss), grad_norm, mx.get_peak_memory()
-
-
 @pytest.mark.fast
 def test_checkpointing_matches_stock_loss_and_gradients():
     model = _TinyFlux2.build(num_layers=2, num_single_layers=6)
     inputs = _TinyFlux2.inputs()
 
-    stock_loss, stock_norm, _ = _run(model, inputs, checkpointing=False, ordered=False)
-    ckpt_loss, ckpt_norm, _ = _run(model, inputs, checkpointing=True, ordered=True)
+    stock_loss, stock_grads, _ = _TinyFlux2.run(model, inputs, checkpointing=False, ordered=False)
+    ckpt_loss, ckpt_grads, _ = _TinyFlux2.run(model, inputs, checkpointing=True, ordered=True)
 
     assert ckpt_loss == pytest.approx(stock_loss, rel=1e-4)
-    assert ckpt_norm == pytest.approx(stock_norm, rel=1e-3)
+    # Every tensor, not one aggregate norm: different gradients can share an L2 norm.
+    assert ckpt_grads.keys() == stock_grads.keys()
+    assert stock_grads
+    for path, stock_grad in stock_grads.items():
+        assert mx.allclose(ckpt_grads[path], stock_grad, rtol=1e-3, atol=1e-6).item(), path
 
 
 @pytest.mark.fast
@@ -97,13 +101,11 @@ def test_ordered_backward_lowers_peak_memory_below_plain_checkpointing():
     model = _TinyFlux2.build(num_layers=2, num_single_layers=12)
     inputs = _TinyFlux2.inputs()
 
-    _, _, stock_peak = _run(model, inputs, checkpointing=False, ordered=False)
-    _, _, ckpt_peak = _run(model, inputs, checkpointing=True, ordered=False)
-    _, _, ordered_peak = _run(model, inputs, checkpointing=True, ordered=True)
+    ckpt_peak = _TinyFlux2.run(model, inputs, checkpointing=True, ordered=False)[2]
+    ordered_peak = _TinyFlux2.run(model, inputs, checkpointing=True, ordered=True)[2]
 
-    # Plain checkpointing helps, but evaluating grads in tree order keeps most recomputed
-    # blocks alive; the ordered backward is what brings the peak down to "a few blocks".
-    assert ckpt_peak < stock_peak
+    # Evaluating the grads in tree order keeps most recomputed blocks alive; the ordered
+    # backward is what brings the peak down to "a few blocks".
     assert ordered_peak < 0.8 * ckpt_peak
 
 

--- a/tests/training/test_gradient_checkpointing.py
+++ b/tests/training/test_gradient_checkpointing.py
@@ -1,0 +1,119 @@
+import mlx.core as mx
+import pytest
+from mlx import nn
+from mlx.utils import tree_flatten
+
+from mflux.models.common.lora.layer.linear_lora_layer import LoRALinear
+from mflux.models.common.training.trainer import TrainingTrainer
+from mflux.models.flux2.model.flux2_transformer.transformer import Flux2Transformer
+
+DIM, HEADS, HEAD_DIM = 128, 4, 32
+IMG_TOKENS, TXT_TOKENS = 512, 16
+
+
+class _TinyFlux2:
+    @staticmethod
+    def build(num_layers: int, num_single_layers: int) -> nn.Module:
+        mx.random.seed(0)
+        transformer = Flux2Transformer(
+            in_channels=32,
+            num_layers=num_layers,
+            num_single_layers=num_single_layers,
+            attention_head_dim=HEAD_DIM,
+            num_attention_heads=HEADS,
+            joint_attention_dim=64,
+            axes_dims_rope=(8, 8, 8, 8),
+        )
+        model = nn.Module()
+        model.transformer = transformer
+        _TinyFlux2._inject_lora(transformer)
+        model.freeze()
+        for _, child in model.named_modules():
+            if isinstance(child, LoRALinear):
+                child.unfreeze(keys=["lora_A", "lora_B"], recurse=False)
+        mx.eval(model.parameters())
+        return model
+
+    @staticmethod
+    def inputs() -> dict:
+        mx.random.seed(1)
+        img_ids = mx.zeros((1, IMG_TOKENS, 4), dtype=mx.int32)
+        txt_ids = mx.zeros((1, TXT_TOKENS, 4), dtype=mx.int32)
+        inputs = {
+            "hidden_states": mx.random.normal((1, IMG_TOKENS, 32)),
+            "encoder_hidden_states": mx.random.normal((1, TXT_TOKENS, 64)),
+            "timestep": mx.array([0.5]),
+            "img_ids": img_ids,
+            "txt_ids": txt_ids,
+        }
+        mx.eval(inputs)
+        return inputs
+
+    @staticmethod
+    def loss(model: nn.Module, inputs: dict) -> mx.array:
+        return model.transformer(**inputs).square().mean()
+
+    @staticmethod
+    def _inject_lora(module: nn.Module) -> None:
+        for key, value in list(module.items()):
+            if isinstance(value, nn.Linear) and not isinstance(value, LoRALinear):
+                module[key] = LoRALinear.from_linear(value, r=4, scale=1.0)
+            elif isinstance(value, nn.Module):
+                _TinyFlux2._inject_lora(value)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, nn.Module):
+                        _TinyFlux2._inject_lora(item)
+
+
+def _run(model: nn.Module, inputs: dict, *, checkpointing: bool, ordered: bool) -> tuple[float, float, int]:
+    model.transformer.gradient_checkpointing = checkpointing
+    mx.reset_peak_memory()
+    value_and_grad = nn.value_and_grad(model, lambda m, i: _TinyFlux2.loss(m, i))
+    loss, grads = value_and_grad(model, inputs)
+    if ordered:
+        TrainingTrainer._evaluate_backward_in_block_order(loss, grads)
+    else:
+        mx.eval(loss, grads)
+    flat = tree_flatten(grads)
+    grad_norm = float(mx.sqrt(sum((g.astype(mx.float32) ** 2).sum() for _, g in flat)))
+    return float(loss), grad_norm, mx.get_peak_memory()
+
+
+@pytest.mark.fast
+def test_checkpointing_matches_stock_loss_and_gradients():
+    model = _TinyFlux2.build(num_layers=2, num_single_layers=6)
+    inputs = _TinyFlux2.inputs()
+
+    stock_loss, stock_norm, _ = _run(model, inputs, checkpointing=False, ordered=False)
+    ckpt_loss, ckpt_norm, _ = _run(model, inputs, checkpointing=True, ordered=True)
+
+    assert ckpt_loss == pytest.approx(stock_loss, rel=1e-4)
+    assert ckpt_norm == pytest.approx(stock_norm, rel=1e-3)
+
+
+@pytest.mark.fast
+def test_ordered_backward_lowers_peak_memory_below_plain_checkpointing():
+    model = _TinyFlux2.build(num_layers=2, num_single_layers=12)
+    inputs = _TinyFlux2.inputs()
+
+    _, _, stock_peak = _run(model, inputs, checkpointing=False, ordered=False)
+    _, _, ckpt_peak = _run(model, inputs, checkpointing=True, ordered=False)
+    _, _, ordered_peak = _run(model, inputs, checkpointing=True, ordered=True)
+
+    # Plain checkpointing helps, but evaluating grads in tree order keeps most recomputed
+    # blocks alive; the ordered backward is what brings the peak down to "a few blocks".
+    assert ckpt_peak < stock_peak
+    assert ordered_peak < 0.8 * ckpt_peak
+
+
+@pytest.mark.fast
+def test_block_prefix_groups_grads_by_block():
+    prefix = TrainingTrainer._BLOCK_PREFIX
+    assert (
+        prefix.match("transformer.transformer_blocks.3.attn.to_q.lora_A").group(1) == "transformer.transformer_blocks.3"
+    )
+    assert prefix.match("transformer.single_transformer_blocks.19.attn.to_out.lora_B").group(1) == "transformer.single_transformer_blocks.19"  # fmt: off
+    assert prefix.match("layers.7.attention.to_q.lora_A").group(1) == "layers.7"
+    assert prefix.match("cap_embedder.1.lora_A").group(1) == "cap_embedder.1"
+    assert prefix.match("transformer.proj_out.lora_A") is None


### PR DESCRIPTION

## What

Edit-LoRA training for FLUX.2 klein is killed by macOS at the very first step on a 36 GB machine, whatever `max_resolution`, `quantize` or `low_ram` is set to: the trainer keeps every transformer block's activations for the backward pass, and for an edit pair (target + reference tokens) on klein-base-4B that is more than the machine has. This PR adds an opt-in `"gradient_checkpointing": true` training-config flag for FLUX.2, Z-Image and Ernie (the mechanism Krea 2 already uses internally) and, because checkpointing alone does not help in MLX unless the gradients are evaluated in the right order, a trainer change that evaluates them last-block-first whenever checkpointing is active. With both, a klein-base-4B edit run that peaked above 50 GB runs on an M5 Max with 36 GB.

## Why checkpointing alone is not enough

MLX builds the backward lazily, and `nn.utils.checkpoint` turns each block's vjp into "recompute the block from its saved input, then differentiate". The trainer used to call `mx.eval` on the whole gradient tree at once, which walks it in parameter order: block 1's gradients first. Producing them needs the cotangent at block 1's output, so every later block is recomputed on the way there, and those recomputations stay referenced until their own gradients are collected further down the tree. The result is that most recomputed activations are alive at the same time and the peak ends up close to the un-checkpointed number.

`TrainingTrainer._evaluate_backward_in_block_order` evaluates the loss first, then the gradients one block at a time from the last block backwards, so only a couple of blocks' recomputed activations exist at any moment. The block is read off the parameter path (the first numeric path segment, e.g. `transformer.single_transformer_blocks.7`), which follows the forward order for all four transformers that can train.

Measured on a small `Flux2Transformer` with LoRA layers (same seed, loss and gradient norm identical to six decimals in every mode):

| blocks (double + single), image tokens | stock | checkpointing, one `mx.eval` in tree order | checkpointing + last-block-first |
|---|---|---|---|
| 2 + 12, 512 (CPU build) | 194 MB | 106 MB | **69 MB** |
| 2 + 12, 512 (Metal, MLX 0.32.0) | 381 MB | 280 MB | **191 MB** |
| 2 + 12, 2048 (Metal) | 2523 MB | 1604 MB | **1250 MB** |
| 5 + 20, 1024 (Metal) | 1318 MB | 715 MB | **468 MB** |

A single `mx.eval` over the gradient leaves in reverse order does not help (312 / 2042 / 1000 MB on the three Metal rows, i.e. worse than tree order), so the per-block `mx.eval` calls are the mechanism, not a stylistic choice. The saving grows with block count and sequence length: on a 26-block variant with 2k tokens the ordered backward reached 13% of the stock peak.

Real run, M5 Max 36 GB, `flux2-klein-base-4b`, edit mode, 12 pairs, target 768×992, reference 576×752, `quantize: 8`, `low_ram: true`, rank 32:

- stock: first step climbs 35 → 47 → 50+ GB, `zsh: killed`
- checkpointing only (this patch minus the ordering): identical, killed at 50+ GB
- checkpointing + last-block-first: runs. Steps were about 30% slower on that run; the per-block evaluation also adds one GPU sync per block, which is a fixed cost that is only visible on toy-sized models.

## Changes

- `TrainingSpec.gradient_checkpointing` (default `false`), parsed from the training JSON and carried through checkpoints, so a resumed run keeps it.
- `TrainingAdapter.set_gradient_checkpointing(enabled)` on the protocol, implemented by every adapter. The FLUX.2, Z-Image and Ernie transformers gain the optional `gradient_checkpointing` attribute Krea 2's transformer already has and wrap each block in `nn.utils.checkpoint` when it is set. The attribute defaults to off, so inference is unaffected; during training previews the wrap is forward-only, exactly as Krea 2 runs today.
- Krea 2 forces checkpointing on in `freeze_base`, so its `set_gradient_checkpointing` keeps it on and the trainer reads the effective state back from the transformer. Krea 2 therefore gets the ordered backward too.
- `TrainingTrainer._evaluate_backward_in_block_order`, applied right after the train step whenever checkpointing is active. Gradient clipping, accumulation and the non-finite skip see fully materialized gradients, as before.
- Docs: the common training README explains what the flag does and when to turn it on; the FLUX.2 README config example gains the field and a tip for 32–36 GB Macs.

## Tests

`tests/training/test_gradient_checkpointing.py`, all marked `fast`, no downloads, CPU-runnable, on a small real `Flux2Transformer` with LoRA layers:

- identical loss (`rel=1e-4`) and, tensor by tensor, identical gradients (`rtol=1e-3`, `atol=1e-6`; the largest observed difference is 1e-6) with and without checkpointing;
- the ordered backward lowers peak memory below plain tree-order checkpointing (`< 0.8×`; 0.68× on Metal, 0.65× on the CPU build. The ratio depends on MLX's allocator, so if a future MLX moves it the threshold is the thing to revisit, not the trainer);
- block-prefix grouping of parameter paths, including non-block paths such as `proj_out`.

## Follow-ups (not in this PR)

- In edit training the `_in` reference is encoded at up to `MAX_REFERENCE_AREA` (1 MP) regardless of `max_resolution`, so lowering `max_resolution` reduces memory less than users expect.
- Training previews render at the preview image's native size (`_preview_dimensions` passes `max_resolution=None`), so a 1584×2048 `preview_1.jpg` makes every preview a 3 MP render.

Both will be filed as issues; a fix that makes `max_resolution` cover the reference and the previews is ready as a separate PR.

- The ordering effect probably applies to any MLX trainer that uses per-layer `mx.checkpoint` and evaluates a full gradient tree at once; mlx-lm may want to check.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default (selector: `-m "not slow and not high_memory_requirement"`, same as `just test`). Only mark `@pytest.mark.slow` or `@pytest.mark.high_memory_requirement` when a test exceeds CI's time or memory budget (typically weight downloads / image generation).
- [x] `ruff check` and `ruff format` are clean (`uv run ruff` uses the version pinned in the dev dependencies of `pyproject.toml`, which is the single source of truth for pre-commit and CI; `pre-commit run -a` covers it locally).
- [x] Release note block below filled in (or `none` for changes users never see).
- [x] Docs updated where behavior changed — README examples/table rows are part of the API contract (see `.cursor/rules/RULE.md`).
- [ ] New model: not applicable.
- [ ] New/changed CLI: not applicable (training config field only).

## Release note

```release-note
Training: new opt-in `"gradient_checkpointing": true` config flag for FLUX.2, Z-Image and Ernie LoRA training, and the backward pass is now evaluated last-block-first whenever checkpointing is active (Krea 2 included), so the memory saving actually materializes. FLUX.2 klein-base-4B edit training fits on 32–36 GB Macs with it.
```

## Verification

```sh
uv run ruff check && uv run ruff format --check          # clean
uv run pytest tests/training/test_gradient_checkpointing.py   # 3 passed (Metal, MLX 0.32.0)
uv run pytest tests/training -m "not slow and not high_memory_requirement"   # 243 passed
```

Real run: `mflux-train` on the klein-base-4B edit config above with `"gradient_checkpointing": true`, `"quantize": 8`, `"low_ram": true` trains on a 36 GB M5 Max; the same config without the flag is killed at step 0. The memory tables above come from a script that builds the test-sized transformer and compares `mx.get_peak_memory()` across the four evaluation strategies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional gradient checkpointing for training to reduce peak memory usage by recomputing activations during backpropagation.
  * Added a `gradient_checkpointing` training configuration option, disabled by default.
  * Supported across FLUX.2, Krea 2, ERNIE Image, and Z Image training workflows.
  * Added memory-conscious backward evaluation to further reduce training memory usage.

* **Documentation**
  * Added guidance for fitting training runs on 32–36 GB machines, including quantization recommendations and expected performance trade-offs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->