### PR TITLE
test: skip the Lens encoder tests when the gpt-oss snapshot has no tokenizer.json

### DIFF
--- a/tests/test_lens_encoder.py
+++ b/tests/test_lens_encoder.py
@@ -30,8 +30,19 @@ class _GptOssCache:
         pattern = os.path.join(hub, "models--mlx-community--gpt-oss-20b-MXFP4-Q8", "snapshots", "*", "tokenizer.json")
         return sorted(os.path.dirname(path) for path in glob.glob(pattern) if os.path.isfile(path))
 
+    @staticmethod
+    def snapshots_with_weights(hub: str) -> list[str]:
+        # LensGptOssEncoder reads config.json and every model*.safetensors shard as well.
+        return [
+            snapshot
+            for snapshot in _GptOssCache.snapshots_with_tokenizer(hub)
+            if os.path.isfile(os.path.join(snapshot, "config.json"))
+            and glob.glob(os.path.join(snapshot, "model*.safetensors"))
+        ]
+
 
 _CACHED_SNAPSHOTS = _GptOssCache.snapshots_with_tokenizer(_HUB)
+_CACHED_WEIGHTS = _GptOssCache.snapshots_with_weights(_HUB)
 
 
 @pytest.mark.fast
@@ -50,6 +61,21 @@ class TestCachedSnapshotGuard:
         snapshot.mkdir(parents=True)
         (snapshot / "tokenizer.json").write_text("{}")
         assert _GptOssCache.snapshots_with_tokenizer(str(tmp_path)) == [str(snapshot)]
+
+    def test_snapshot_without_weights_has_no_weights(self, tmp_path):
+        # The parity test builds the whole encoder, so a tokenizer-only snapshot must not qualify.
+        snapshot = tmp_path / "models--mlx-community--gpt-oss-20b-MXFP4-Q8" / "snapshots" / "abc123"
+        snapshot.mkdir(parents=True)
+        (snapshot / "tokenizer.json").write_text("{}")
+        (snapshot / "config.json").write_text("{}")
+        assert _GptOssCache.snapshots_with_weights(str(tmp_path)) == []
+
+    def test_snapshot_with_config_and_shard_has_weights(self, tmp_path):
+        snapshot = tmp_path / "models--mlx-community--gpt-oss-20b-MXFP4-Q8" / "snapshots" / "abc123"
+        snapshot.mkdir(parents=True)
+        for name in ("tokenizer.json", "config.json", "model-00001-of-00002.safetensors"):
+            (snapshot / name).write_text("{}")
+        assert _GptOssCache.snapshots_with_weights(str(tmp_path)) == [str(snapshot)]
 
 
 @pytest.mark.fast
@@ -130,14 +156,14 @@ class TestTemplateTokenization:
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(not _CACHED_SNAPSHOTS, reason="gpt-oss checkpoint not cached locally")
+@pytest.mark.skipif(not _CACHED_WEIGHTS, reason="gpt-oss checkpoint not cached locally")
 class TestLensEncoderParity:
     def test_features_match_battery_022_reference(self):
         ref_path = os.path.join(os.path.dirname(__file__), "resources", "lens", "lens_exp1_features.npz")
         if not os.path.exists(ref_path):
             pytest.skip("reference features not present")
         ref = np.load(ref_path)
-        encoder = LensGptOssEncoder(_CACHED_SNAPSHOTS[0])
+        encoder = LensGptOssEncoder(_CACHED_WEIGHTS[0])
         features = encoder.encode(ref["prompt"].item())
         ours = np.array(features.astype(mx.float32))
         theirs = ref["features"]

--- a/tests/test_lens_encoder.py
+++ b/tests/test_lens_encoder.py
@@ -20,7 +20,36 @@ from mflux.models.lens.model.text_encoder.lens_prompt_template import (
 )
 
 _HUB = os.environ.get("HF_HUB_CACHE", os.path.expanduser("~/.cache/huggingface/hub"))
-_CACHED_SNAPSHOTS = glob.glob(os.path.join(_HUB, "models--mlx-community--gpt-oss-20b-MXFP4-Q8", "snapshots", "*"))
+
+
+class _GptOssCache:
+    @staticmethod
+    def snapshots_with_tokenizer(hub: str) -> list[str]:
+        # A snapshot directory alone is not enough: an interrupted download leaves config and
+        # index files without tokenizer.json, and the guarded tests need the tokenizer.
+        pattern = os.path.join(hub, "models--mlx-community--gpt-oss-20b-MXFP4-Q8", "snapshots", "*", "tokenizer.json")
+        return sorted(os.path.dirname(path) for path in glob.glob(pattern) if os.path.isfile(path))
+
+
+_CACHED_SNAPSHOTS = _GptOssCache.snapshots_with_tokenizer(_HUB)
+
+
+@pytest.mark.fast
+class TestCachedSnapshotGuard:
+    def test_snapshot_without_tokenizer_is_not_cached(self, tmp_path):
+        # A download that stopped before tokenizer.json (config and index present) must read as
+        # absent, otherwise the guarded tests crash on Tokenizer.from_file instead of skipping.
+        snapshot = tmp_path / "models--mlx-community--gpt-oss-20b-MXFP4-Q8" / "snapshots" / "abc123"
+        snapshot.mkdir(parents=True)
+        (snapshot / "config.json").write_text("{}")
+        (snapshot / "model.safetensors.index.json").write_text("{}")
+        assert _GptOssCache.snapshots_with_tokenizer(str(tmp_path)) == []
+
+    def test_snapshot_with_tokenizer_is_cached(self, tmp_path):
+        snapshot = tmp_path / "models--mlx-community--gpt-oss-20b-MXFP4-Q8" / "snapshots" / "abc123"
+        snapshot.mkdir(parents=True)
+        (snapshot / "tokenizer.json").write_text("{}")
+        assert _GptOssCache.snapshots_with_tokenizer(str(tmp_path)) == [str(snapshot)]
 
 
 @pytest.mark.fast


### PR DESCRIPTION
## What

Three fast tests in `tests/test_lens_encoder.py` crash instead of skipping when the gpt-oss checkpoint is only partly downloaded. The skip guard checked that a snapshot directory exists; an interrupted download leaves the directory with config and index files but no `tokenizer.json`, so the guard let the tests run and `Tokenizer.from_file` failed with "No such file or directory". The guard now requires `tokenizer.json` inside the snapshot, and a small test covers both the partial and the complete case. Fixes #712. The slow parity test builds the whole encoder, so it gets a stricter guard that also requires `config.json` and a weight shard.

## Checklist (definition of done)

- [x] Tests added/updated run in CI by default (selector: `-m "not slow and not high_memory_requirement"`, same as `just test`). Only mark `@pytest.mark.slow` or `@pytest.mark.high_memory_requirement` when a test exceeds CI's time or memory budget (typically weight downloads / image generation).
- [x] `ruff check` and `ruff format` are clean (`uv run ruff` uses the version pinned in the dev dependencies of `pyproject.toml`, which is the single source of truth for pre-commit and CI; `pre-commit run -a` covers it locally).
- [x] Release note block below filled in (or `none` for changes users never see).
- [ ] Docs updated where behavior changed — README examples/table rows are part of the API contract (see `.cursor/rules/RULE.md`).
- [ ] New model: shared config wiring (aliases, default steps, mflux-save dispatch, capabilities, completions), thin CLI entrypoint, and `src/mflux/models/<name>/README.md`.
- [ ] New/changed CLI: ignored/rejected options declared (`IGNORED_OPTIONS`/`REJECTED_OPTIONS`) and `warn_ignored_options` actually called in `main()` — `mflux-capabilities` must stay truthful.

## Release note

```release-note
none
```

## Verification

On an M1 Max, mlx 0.32.0, with a partial gpt-oss snapshot in the cache (no `tokenizer.json`):

- before: `uv run python -m pytest tests/test_lens_encoder.py -q` gives 3 failed with `No such file or directory (os error 2)`
- after: 6 passed, 4 skipped ("gpt-oss checkpoint not cached locally"); the two new guard tests pass, and widening the glob back to `snapshots/*` makes `test_snapshot_without_tokenizer_is_not_cached` fail
- `ruff check` and `ruff format --check` clean on the file


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tightens the Lens encoder test cache guard so partially downloaded GPT-OSS snapshots without `tokenizer.json` are skipped rather than executed.
- Adds a helper that returns only snapshot directories containing a tokenizer file.
- Adds fast tests covering snapshots with and without `tokenizer.json`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code defects identified.

The guard now admits a strict subset of the snapshots admitted previously and directly prevents tokenizer-dependent tests from running when the required tokenizer file is absent.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tests/test_lens_encoder.py | The new cache predicate and focused tests correctly narrow the previous directory-only guard without introducing a changed-code regression. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: skip the Lens encoder tests when t..."](https://github.com/mflux-community/mflux/commit/3eab8e26d204f3d2e1642d9e804378b609d004e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60931128)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint cache detection so incomplete downloads missing tokenizer or model-weight files are not treated as fully cached.

* **Tests**
  * Added coverage for snapshots with missing tokenizers, missing weights, and complete checkpoint files.
  * Updated encoder parity checks to run only when complete model weights are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
