### PR TITLE
fix: evaluate Z-Image's RoPE tables at construction so a seed's output is stable across a process

### DIFF
--- a/src/mflux/models/z_image/model/z_image_transformer/rope_embedder.py
+++ b/src/mflux/models/z_image/model/z_image_transformer/rope_embedder.py
@@ -15,6 +15,11 @@ class RopeEmbedder:
 
         self.axes_dims = axes_dims
         self.freqs_cis = RopeEmbedder._precompute_freqs_cis(axes_dims, axes_lens, theta)
+        # Materialise the tables now: they are plain arrays outside the module's parameter tree,
+        # so nothing else evaluates them. Left lazy, they are captured as a pending graph by the
+        # first mx.compile of predict and diverge from a later eager touch, changing the output
+        # across generate_image calls in the same process (issue #714). Three small float32 arrays.
+        mx.eval(*self.freqs_cis)
 
     def __call__(self, ids: mx.array) -> mx.array:
         result = []

--- a/tests/test_z_image_rope_embedder.py
+++ b/tests/test_z_image_rope_embedder.py
@@ -3,38 +3,34 @@ import mlx.core as mx
 from mflux.models.z_image.model.z_image_transformer.rope_embedder import RopeEmbedder
 
 
-def _rope() -> RopeEmbedder:
-    # The geometry the Z-Image transformer builds (axes_dims / axes_lens from
-    # z_image_transformer.transformer). Constructed directly: no weights, no model load.
-    return RopeEmbedder(theta=256.0, axes_dims=[32, 48, 48], axes_lens=[1024, 512, 512])
+class TestRopeEmbedderEagerEval:
+    @staticmethod
+    def _rope() -> RopeEmbedder:
+        # The geometry z_image_transformer builds; constructed directly, no weights, no model load.
+        return RopeEmbedder(theta=256.0, axes_dims=[32, 48, 48], axes_lens=[1024, 512, 512])
 
+    @staticmethod
+    def _pos_ids() -> mx.array:
+        n = mx.arange(8)
+        return mx.stack([n, n % 512, n % 512], axis=1).astype(mx.int32)
 
-def _pos_ids() -> mx.array:
-    # (N, 3): one token index and two spatial indices, each below its axis length.
-    n = mx.arange(8)
-    return mx.stack([n, n % 512, n % 512], axis=1).astype(mx.int32)
+    def test_rope_output_survives_a_recompile_after_the_tables_are_touched(self):
+        # Regression for issue #714: a fresh mx.compile after the RoPE tables are eagerly evaluated
+        # must give the same output as the first compile. Left lazy, the tables are captured as a
+        # pending graph and the next compile picks up different values, so a seed's image depended
+        # on process history. Reproduces on the pinned mlx 0.32 (mlx 0.31 did not drift); delete the
+        # mx.eval in RopeEmbedder.__init__ to see it go red.
+        ids = self._pos_ids()
+        rope = self._rope()
 
+        first_fn = mx.compile(lambda pos: rope(pos))
+        first = first_fn(ids)
+        mx.eval(first)
 
-def test_rope_output_survives_a_recompile_after_the_tables_are_touched():
-    # Z-Image wraps `predict` in mx.compile and rebuilds it every generate_image call. When the
-    # RoPE cos/sin tables are left unevaluated, the first compiled call inlines their pending
-    # graph; a later eager touch of the same tables materialises them; and the next fresh compile
-    # then captures those materialised values, so one seed produces a different image depending on
-    # what ran earlier in the process (issue #714). Evaluating the tables in __init__ makes them
-    # constants before any compile sees them. Reproduces on mlx 0.32.x, which mflux 0.19 pins;
-    # mlx 0.31 traced the tables identically. Delete the mx.eval in RopeEmbedder.__init__ and this
-    # goes red on 0.32.
-    ids = _pos_ids()
-    rope = _rope()
+        mx.eval(*rope.freqs_cis)  # eager touch between the two compiled functions
 
-    first_fn = mx.compile(lambda pos: rope(pos))
-    first = first_fn(ids)
-    mx.eval(first)
+        second_fn = mx.compile(lambda pos: rope(pos))
+        second = second_fn(ids)
+        mx.eval(second)
 
-    mx.eval(*rope.freqs_cis)  # an eager touch between the two compiled functions
-
-    second_fn = mx.compile(lambda pos: rope(pos))
-    second = second_fn(ids)
-    mx.eval(second)
-
-    assert mx.array_equal(first, second).item()
+        assert mx.array_equal(first, second).item()

--- a/tests/test_z_image_rope_embedder.py
+++ b/tests/test_z_image_rope_embedder.py
@@ -1,0 +1,40 @@
+import mlx.core as mx
+
+from mflux.models.z_image.model.z_image_transformer.rope_embedder import RopeEmbedder
+
+
+def _rope() -> RopeEmbedder:
+    # The geometry the Z-Image transformer builds (axes_dims / axes_lens from
+    # z_image_transformer.transformer). Constructed directly: no weights, no model load.
+    return RopeEmbedder(theta=256.0, axes_dims=[32, 48, 48], axes_lens=[1024, 512, 512])
+
+
+def _pos_ids() -> mx.array:
+    # (N, 3): one token index and two spatial indices, each below its axis length.
+    n = mx.arange(8)
+    return mx.stack([n, n % 512, n % 512], axis=1).astype(mx.int32)
+
+
+def test_rope_output_survives_a_recompile_after_the_tables_are_touched():
+    # Z-Image wraps `predict` in mx.compile and rebuilds it every generate_image call. When the
+    # RoPE cos/sin tables are left unevaluated, the first compiled call inlines their pending
+    # graph; a later eager touch of the same tables materialises them; and the next fresh compile
+    # then captures those materialised values, so one seed produces a different image depending on
+    # what ran earlier in the process (issue #714). Evaluating the tables in __init__ makes them
+    # constants before any compile sees them. Reproduces on mlx 0.32.x, which mflux 0.19 pins;
+    # mlx 0.31 traced the tables identically. Delete the mx.eval in RopeEmbedder.__init__ and this
+    # goes red on 0.32.
+    ids = _pos_ids()
+    rope = _rope()
+
+    first_fn = mx.compile(lambda pos: rope(pos))
+    first = first_fn(ids)
+    mx.eval(first)
+
+    mx.eval(*rope.freqs_cis)  # an eager touch between the two compiled functions
+
+    second_fn = mx.compile(lambda pos: rope(pos))
+    second = second_fn(ids)
+    mx.eval(second)
+
+    assert mx.array_equal(first, second).item()


### PR DESCRIPTION
## What

Z-Image's `RopeEmbedder` builds its rotary-embedding tables in `__init__` but never evaluates them, so they stay a pending graph. The class is a plain object rather than an `nn.Module`, so its tables are not in the parameter tree that gets evaluated when the weights load. Z-Image compiles `predict` and rebuilds it on every `generate_image` call. The first compiled run traces the pending tables; once anything materialises them eagerly, the next run captures different values. The same seed then gives a different image depending on what ran earlier in the process.

The fix evaluates the three small float32 tables once when the embedder is built, before any compile sees them.

Fixes #714.

## Release note

```release-note
Fix Z-Image producing a different image for the same seed when other code (a preview callback, another library) had run the model earlier in the same process.
```

## Verification

M1 Max 32 GB, mflux 0.19.1, mlx 0.32.2. Before the fix, evaluating the tables between two same-seed runs changed the decoded 512x512 image by up to 83 of 255 per channel across about three quarters of the pixels. After, the two runs are byte-identical.

New test `tests/test_z_image_rope_embedder.py` (no weights, runs in the default selector): compile the embedder, touch its tables, compile again, and assert the two outputs match. Red without the fix on mlx 0.32, green with it. Local fast suite: 1589 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of generated images across repeated calls in the same process.
  - Prevented positional embedding calculations from producing different results depending on prior evaluations.
  - Ensured precomputed positional data is ready before image generation begins.

- **Tests**
  - Added coverage verifying identical outputs before and after eager evaluation and compilation.
  - Organized regression coverage for positional embedding consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR eagerly evaluates Z-Image’s precomputed RoPE tables during embedder construction so subsequent compiled prediction functions capture stable values.
- Adds a one-time `mx.eval` for the three float32 RoPE tables.
- Adds a focused regression test matching production geometry, input dtype, and recompilation behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the eager evaluation correctly placed before any production compilation path.

The change evaluates three small RoPE tables once during eager model initialization, and the regression test accurately reflects the production table geometry, input contract, and fresh-compile lifecycle.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mflux/models/z_image/model/z_image_transformer/rope_embedder.py | Materializes small, non-parameter RoPE tables before compiled prediction paths can observe different lazy/eager states; no defect identified. |
| tests/test_z_image_rope_embedder.py | Covers the reported recompilation instability using production-equivalent geometry and position-ID shape and dtype; no defect identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: evaluate Z-Image&#39;s RoPE tables at c..."](https://github.com/mflux-community/mflux/commit/e39799d52636db862e533932461dc1e6c67c28de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60970527)</sub>

<!-- /greptile_comment -->