### PR TITLE
fix: independent components sharing an hf_subdir no longer collide on save

### DIFF
--- a/src/mflux/models/common/weights/loading/weight_definition.py
+++ b/src/mflux/models/common/weights/loading/weight_definition.py
@@ -52,6 +52,38 @@ class ComponentDefinition:
     # single-file checkpoint vs a diffusers sharded directory with different keys).
     variant_selector: Callable[[Path], "ComponentDefinition"] | None = None
 
+    @staticmethod
+    def save_subdirs(components: "List[ComponentDefinition]") -> dict:
+        # Where ModelSaver writes each component and where the loader probes for an
+        # mflux-saved one. Normally the hf_subdir; but two independent components that share
+        # one (SeedVR2's transformer and vae both sit flat at repo root, told apart on load
+        # by weight_files) would overwrite each other's shards and index there. Give an
+        # independent component its own <hf_subdir>/<name> directory whenever anything else
+        # shares its hf_subdir.
+        #
+        # A component that carves a subset out of a shared source with weight_prefix_filters
+        # (FIBO VLM's decoder and visual read the same files and split them by prefix) is a
+        # deliberate shared-source split, so it keeps its hf_subdir; the count includes it,
+        # so an independent component next to it is still moved out of the way. Every model
+        # with unique subdirs is returned unchanged.
+        #
+        # Computed from the static definition, matching ModelSaver, which writes to that same
+        # hf_subdir and never runs variant_selector, so the loader's probe here agrees with
+        # where the checkpoint was written. Keyed on the raw hf_subdir string: no shipped
+        # model spells one directory two ways, and normalizing "" to "." would wrongly merge
+        # FIBO VLM's decoder/visual ("") with its fibo_vlm (".") component.
+        counts: dict = {}
+        for c in components:
+            counts[c.hf_subdir] = counts.get(c.hf_subdir, 0) + 1
+        return {
+            c.name: (
+                str(Path(c.hf_subdir) / c.name)
+                if counts[c.hf_subdir] > 1 and c.weight_prefix_filters is None
+                else c.hf_subdir
+            )
+            for c in components
+        }
+
 
 @dataclass
 class TokenizerDefinition:

--- a/src/mflux/models/common/weights/loading/weight_definition.py
+++ b/src/mflux/models/common/weights/loading/weight_definition.py
@@ -53,7 +53,7 @@ class ComponentDefinition:
     variant_selector: Callable[[Path], "ComponentDefinition"] | None = None
 
     @staticmethod
-    def save_subdirs(components: "List[ComponentDefinition]") -> dict:
+    def save_subdirs(components: "List[ComponentDefinition]") -> dict[str, str]:
         # Where ModelSaver writes each component and where the loader probes for an
         # mflux-saved one. Normally the hf_subdir; but two independent components that share
         # one (SeedVR2's transformer and vae both sit flat at repo root, told apart on load
@@ -72,7 +72,7 @@ class ComponentDefinition:
         # where the checkpoint was written. Keyed on the raw hf_subdir string: no shipped
         # model spells one directory two ways, and normalizing "" to "." would wrongly merge
         # FIBO VLM's decoder/visual ("") with its fibo_vlm (".") component.
-        counts: dict = {}
+        counts: dict[str, int] = {}
         for c in components:
             counts[c.hf_subdir] = counts.get(c.hf_subdir, 0) + 1
         return {

--- a/src/mflux/models/common/weights/loading/weight_definition.py
+++ b/src/mflux/models/common/weights/loading/weight_definition.py
@@ -54,31 +54,21 @@ class ComponentDefinition:
 
     @staticmethod
     def save_subdirs(components: "List[ComponentDefinition]") -> dict[str, str]:
-        # Where ModelSaver writes each component and where the loader probes for an
-        # mflux-saved one. Normally the hf_subdir; but two independent components that share
-        # one (SeedVR2's transformer and vae both sit flat at repo root, told apart on load
-        # by weight_files) would overwrite each other's shards and index there. Give an
-        # independent component its own <hf_subdir>/<name> directory whenever anything else
-        # shares its hf_subdir.
-        #
-        # A component that carves a subset out of a shared source with weight_prefix_filters
-        # (FIBO VLM's decoder and visual read the same files and split them by prefix) is a
-        # deliberate shared-source split, so it keeps its hf_subdir; the count includes it,
-        # so an independent component next to it is still moved out of the way. Every model
-        # with unique subdirs is returned unchanged.
-        #
-        # Computed from the static definition, matching ModelSaver, which writes to that same
-        # hf_subdir and never runs variant_selector, so the loader's probe here agrees with
-        # where the checkpoint was written. Keyed on the raw hf_subdir string: no shipped
-        # model spells one directory two ways, and normalizing "" to "." would wrongly merge
-        # FIBO VLM's decoder/visual ("") with its fibo_vlm (".") component.
+        # Where ModelSaver writes each component and where the loader probes for an mflux-saved
+        # one. Two independent components that share a directory (SeedVR2's transformer and vae
+        # both sit flat at repo root, told apart on load by weight_files) would overwrite each
+        # other's shards and index, so each gets its own <hf_subdir>/<name>. A prefix-filtered
+        # shared-source split (FIBO VLM's decoder and visual read the same files) keeps its
+        # hf_subdir. Grouped by the resolved directory, so "" and "." count as one; matches
+        # ModelSaver, which writes the static hf_subdir and never runs variant_selector.
         counts: dict[str, int] = {}
         for c in components:
-            counts[c.hf_subdir] = counts.get(c.hf_subdir, 0) + 1
+            resolved = str(Path(c.hf_subdir))
+            counts[resolved] = counts.get(resolved, 0) + 1
         return {
             c.name: (
                 str(Path(c.hf_subdir) / c.name)
-                if counts[c.hf_subdir] > 1 and c.weight_prefix_filters is None
+                if counts[str(Path(c.hf_subdir))] > 1 and c.weight_prefix_filters is None
                 else c.hf_subdir
             )
             for c in components

--- a/src/mflux/models/common/weights/loading/weight_loader.py
+++ b/src/mflux/models/common/weights/loading/weight_loader.py
@@ -83,8 +83,14 @@ class WeightLoader:
         mflux_version = None
         raw_weights_cache: dict[tuple, dict] = {}  # Cache by (path, loading_mode, weight_files)
 
+        # An mflux-saved checkpoint lives under each component's save subdir, which differs
+        # from its hf_subdir only when components share one (SeedVR2); the HuggingFace layout
+        # is still addressed by hf_subdir below (#621).
+        save_subdirs = ComponentDefinition.save_subdirs(weight_definition.get_components())
         for component in weight_definition.get_components():
-            weights, q_level, version = WeightLoader._load_component(root_path, component, raw_weights_cache)
+            weights, q_level, version = WeightLoader._load_component(
+                root_path, component, raw_weights_cache, save_subdirs[component.name]
+            )
             components[component.name] = weights
 
             # Track metadata from first component that has it
@@ -105,6 +111,7 @@ class WeightLoader:
         root_path: Path | None,
         component: ComponentDefinition,
         raw_weights_cache: dict[tuple, dict] | None = None,
+        save_subdir: str | None = None,
     ) -> tuple[dict, int | None, str | None]:
         # Some components are distributed in more than one on-disk layout (e.g. a native
         # single-file checkpoint vs a diffusers sharded directory with different keys).
@@ -122,7 +129,11 @@ class WeightLoader:
             component_path = root_path / component.hf_subdir
 
             # Try mflux saved format first (including FP8 components reloaded after mflux-save).
-            weights, q_level, version = WeightLoader._try_load_mflux_format(component_path)
+            # ModelSaver writes to the save subdir, which is the hf_subdir for every model
+            # except the shared-subdir case (SeedVR2); the HuggingFace fallback below still
+            # reads the hf_subdir layout (#621).
+            mflux_path = root_path / save_subdir if save_subdir is not None else component_path
+            weights, q_level, version = WeightLoader._try_load_mflux_format(mflux_path)
             if weights is not None:
                 return weights, q_level, version
 

--- a/src/mflux/models/common/weights/saving/model_saver.py
+++ b/src/mflux/models/common/weights/saving/model_saver.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 from transformers import PreTrainedTokenizer
 
 from mflux.models.common.lora.mapping.lora_saver import LoRASaver
+from mflux.models.common.weights.loading.weight_definition import ComponentDefinition
 from mflux.utils.version_util import VersionUtil
 
 if TYPE_CHECKING:
@@ -26,13 +27,17 @@ class ModelSaver:
         # Bake and strip any LoRA wrappers (to avoid duplicating shared weights) across
         # every component before writing a single file: baking raises when an adapter does
         # not fit, and that must abort before part of a checkpoint is on disk.
+        # Write each component to its save subdir, not its hf_subdir: the two differ only
+        # when components share an hf_subdir (SeedVR2), where saving to the shared directory
+        # would overwrite one component's shards and index with the other's (#621).
+        save_subdirs = ComponentDefinition.save_subdirs(weight_definition.get_components())
         components = []
         for component_def in weight_definition.get_components():
             attr_name = component_def.model_attr or component_def.name
             component = getattr(model, attr_name, None)
             if component is not None:
                 LoRASaver.bake_and_strip_lora(component)
-                components.append((component, component_def.hf_subdir))
+                components.append((component, save_subdirs[component_def.name]))
 
         # Save tokenizers from model.tokenizers dict
         tokenizer_defs = weight_definition.get_tokenizers()

--- a/src/mflux/models/common/weights/saving/model_saver.py
+++ b/src/mflux/models/common/weights/saving/model_saver.py
@@ -31,6 +31,27 @@ class ModelSaver:
         # when components share an hf_subdir (SeedVR2), where saving to the shared directory
         # would overwrite one component's shards and index with the other's (#621).
         save_subdirs = ComponentDefinition.save_subdirs(weight_definition.get_components())
+
+        # No two components that are actually written may land in the same directory, or the
+        # second's shards and index overwrite the first's (#621). save_subdirs separates
+        # independent components; this catches the case it deliberately leaves alone — a
+        # prefix-filtered shared-source pair (FIBO VLM) is only safe because just one of the
+        # pair is a real attribute, so only one is written. Checked before anything reaches
+        # disk, and by attribute presence so a nested/aliased component that is not written
+        # is not counted.
+        written_dirs: dict[str, str] = {}
+        for component_def in weight_definition.get_components():
+            attr_name = component_def.model_attr or component_def.name
+            if getattr(model, attr_name, None) is None:
+                continue
+            subdir = save_subdirs[component_def.name]
+            if subdir in written_dirs:
+                raise ValueError(
+                    f"Components '{written_dirs[subdir]}' and '{component_def.name}' both save to "
+                    f"'{subdir or '.'}'; give them distinct hf_subdirs so their checkpoints do not collide."
+                )
+            written_dirs[subdir] = component_def.name
+
         components = []
         for component_def in weight_definition.get_components():
             attr_name = component_def.model_attr or component_def.name

--- a/src/mflux/models/common/weights/saving/model_saver.py
+++ b/src/mflux/models/common/weights/saving/model_saver.py
@@ -32,25 +32,23 @@ class ModelSaver:
         # would overwrite one component's shards and index with the other's (#621).
         save_subdirs = ComponentDefinition.save_subdirs(weight_definition.get_components())
 
-        # No two components that are actually written may land in the same directory, or the
-        # second's shards and index overwrite the first's (#621). save_subdirs separates
-        # independent components; this catches the case it deliberately leaves alone — a
-        # prefix-filtered shared-source pair (FIBO VLM) is only safe because just one of the
-        # pair is a real attribute, so only one is written. Checked before anything reaches
-        # disk, and by attribute presence so a nested/aliased component that is not written
-        # is not counted.
+        # No two written components may resolve to the same directory, or the second's shards
+        # and index overwrite the first's (#621). save_subdirs separates independent
+        # components; this catches a shared-source pair mis-declared so both are written.
+        # Keyed on the resolved path, so "" and "." are one directory; by attribute presence,
+        # so a nested component that is not written is not counted; before any write.
         written_dirs: dict[str, str] = {}
         for component_def in weight_definition.get_components():
             attr_name = component_def.model_attr or component_def.name
             if getattr(model, attr_name, None) is None:
                 continue
-            subdir = save_subdirs[component_def.name]
-            if subdir in written_dirs:
+            resolved = str(Path(save_subdirs[component_def.name]))
+            if resolved in written_dirs:
                 raise ValueError(
-                    f"Components '{written_dirs[subdir]}' and '{component_def.name}' both save to "
-                    f"'{subdir or '.'}'; give them distinct hf_subdirs so their checkpoints do not collide."
+                    f"Components '{written_dirs[resolved]}' and '{component_def.name}' both save to "
+                    f"'{resolved}'; give them distinct hf_subdirs so their checkpoints do not collide."
                 )
-            written_dirs[subdir] = component_def.name
+            written_dirs[resolved] = component_def.name
 
         components = []
         for component_def in weight_definition.get_components():

--- a/tests/model_saving/test_model_saver_shared_subdir.py
+++ b/tests/model_saving/test_model_saver_shared_subdir.py
@@ -1,0 +1,55 @@
+import pytest
+from mlx import nn
+
+from mflux.models.common.weights.loading.weight_definition import ComponentDefinition
+from tests.model_saving.tiny_checkpoint_helper import TinyCheckpointRoundtrip
+
+
+class _TinyComponent(nn.Module):
+    # Two Linears whose last dim is a multiple of 64, so the definition's predicate
+    # quantizes them and the save/load path carries real quantized tensors.
+    def __init__(self) -> None:
+        super().__init__()
+        self.a = nn.Linear(64, 64)
+        self.b = nn.Linear(64, 64)
+
+
+class _SharedSubdirDefinition:
+    # The SeedVR2 layout: two non-tokenizer components that both sit flat at repo root
+    # (hf_subdir="."). On the real repo, weight_files tells them apart on load. On save,
+    # both would write 0.safetensors and model.safetensors.index.json into the same
+    # directory, so the second clobbers the first (issue #621).
+    @staticmethod
+    def get_components() -> list[ComponentDefinition]:
+        return [
+            ComponentDefinition(name="transformer", hf_subdir=".", loading_mode="mlx_native"),
+            ComponentDefinition(name="vae", hf_subdir=".", loading_mode="mlx_native"),
+        ]
+
+    @staticmethod
+    def get_tokenizers() -> list:
+        return []
+
+    @staticmethod
+    def get_download_patterns() -> list[str]:
+        return ["**/*.safetensors"]
+
+    @staticmethod
+    def quantization_predicate(path: str, module) -> bool:
+        return isinstance(module, nn.Linear) and module.weight.shape[-1] % 64 == 0
+
+
+class TestModelSaverSharedSubdir:
+    @pytest.mark.fast
+    def test_two_components_sharing_a_subdir_roundtrip_without_collision(self, tmp_path):
+        # RED without the fix: transformer and vae both save into the same directory
+        # (hf_subdir="."), so the second overwrites the first's shards and index, and on
+        # reload the transformer comes back with the VAE's weights. GREEN once ModelSaver
+        # and WeightLoader give each shared-subdir component its own <subdir>/<name>
+        # directory. Issue #621.
+        TinyCheckpointRoundtrip.save_and_reload_expecting_identical_weights(
+            weight_definition=_SharedSubdirDefinition,
+            make_components=lambda: {"transformer": _TinyComponent(), "vae": _TinyComponent()},
+            base_path=tmp_path / "shared_subdir_tiny_q8",
+            bits=8,
+        )

--- a/tests/model_saving/test_model_saver_shared_subdir.py
+++ b/tests/model_saving/test_model_saver_shared_subdir.py
@@ -57,11 +57,8 @@ class TestModelSaverSharedSubdir:
 
     @pytest.mark.fast
     def test_two_written_components_in_the_same_directory_raise(self, tmp_path):
-        # save_subdirs cannot separate a shared-source pair (both prefix-filtered keep the
-        # shared hf_subdir), and it is not meant to: FIBO VLM's filtered decoder/visual are
-        # nested, so only one is ever written. But if a definition ever puts two components
-        # that are BOTH written into one directory, the second would silently overwrite the
-        # first's shards and index (#621). ModelSaver must fail loudly instead.
+        # If a definition ever writes two components into one directory, the second would
+        # silently overwrite the first's shards and index (#621); ModelSaver must fail loudly.
         class _FilteredPairDefinition:
             @staticmethod
             def get_components():
@@ -85,4 +82,44 @@ class TestModelSaverSharedSubdir:
                 bits=8,
                 base_path=str(tmp_path / "collide"),
                 weight_definition=_FilteredPairDefinition,
+            )
+
+    def test_independent_components_spelled_empty_and_dot_do_not_collide(self):
+        # "" and "." are the same directory. Two independent components spelled differently
+        # must still be separated, not left to overwrite each other (#621).
+        components = [
+            ComponentDefinition(name="a", hf_subdir=""),
+            ComponentDefinition(name="b", hf_subdir="."),
+        ]
+        subdirs = ComponentDefinition.save_subdirs(components)
+        from pathlib import Path
+
+        assert str(Path(subdirs["a"])) != str(Path(subdirs["b"]))
+
+    def test_guard_catches_a_collision_spelled_empty_and_dot(self, tmp_path):
+        # The save-time guard compares resolved directories, so a shared-source pair spelled
+        # "" and "." (which save_subdirs leaves in place) is still caught, not missed (#621).
+        class _FilteredDotPairDefinition:
+            @staticmethod
+            def get_components():
+                return [
+                    ComponentDefinition(name="a", hf_subdir="", weight_prefix_filters=["x"]),
+                    ComponentDefinition(name="b", hf_subdir=".", weight_prefix_filters=["y"]),
+                ]
+
+            @staticmethod
+            def get_tokenizers():
+                return []
+
+        class _Model:
+            def __init__(self):
+                self.a = _TinyComponent()
+                self.b = _TinyComponent()
+
+        with pytest.raises(ValueError, match="both save to"):
+            ModelSaver.save_model(
+                model=_Model(),
+                bits=8,
+                base_path=str(tmp_path / "collide_dot"),
+                weight_definition=_FilteredDotPairDefinition,
             )

--- a/tests/model_saving/test_model_saver_shared_subdir.py
+++ b/tests/model_saving/test_model_saver_shared_subdir.py
@@ -2,6 +2,7 @@ import pytest
 from mlx import nn
 
 from mflux.models.common.weights.loading.weight_definition import ComponentDefinition
+from mflux.models.common.weights.saving.model_saver import ModelSaver
 from tests.model_saving.tiny_checkpoint_helper import TinyCheckpointRoundtrip
 
 
@@ -53,3 +54,35 @@ class TestModelSaverSharedSubdir:
             base_path=tmp_path / "shared_subdir_tiny_q8",
             bits=8,
         )
+
+    @pytest.mark.fast
+    def test_two_written_components_in_the_same_directory_raise(self, tmp_path):
+        # save_subdirs cannot separate a shared-source pair (both prefix-filtered keep the
+        # shared hf_subdir), and it is not meant to: FIBO VLM's filtered decoder/visual are
+        # nested, so only one is ever written. But if a definition ever puts two components
+        # that are BOTH written into one directory, the second would silently overwrite the
+        # first's shards and index (#621). ModelSaver must fail loudly instead.
+        class _FilteredPairDefinition:
+            @staticmethod
+            def get_components():
+                return [
+                    ComponentDefinition(name="a", hf_subdir="", weight_prefix_filters=["x"]),
+                    ComponentDefinition(name="b", hf_subdir="", weight_prefix_filters=["y"]),
+                ]
+
+            @staticmethod
+            def get_tokenizers():
+                return []
+
+        class _Model:
+            def __init__(self):
+                self.a = _TinyComponent()
+                self.b = _TinyComponent()
+
+        with pytest.raises(ValueError, match="both save to"):
+            ModelSaver.save_model(
+                model=_Model(),
+                bits=8,
+                base_path=str(tmp_path / "collide"),
+                weight_definition=_FilteredPairDefinition,
+            )

--- a/tests/model_saving/test_tiny_model_saving_seedvr2.py
+++ b/tests/model_saving/test_tiny_model_saving_seedvr2.py
@@ -1,0 +1,41 @@
+import pytest
+
+from mflux.models.seedvr2.model.seedvr2_transformer.transformer import SeedVR2Transformer
+from mflux.models.seedvr2.model.seedvr2_vae.vae import SeedVR2VAE
+from mflux.models.seedvr2.weights.seedvr2_weight_definition import SeedVR2WeightDefinition3B
+from tests.model_saving.tiny_checkpoint_helper import TinyCheckpointRoundtrip
+
+
+class TestTinySeedVR2ModelSaving:
+    @pytest.mark.fast
+    def test_tiny_quantized_checkpoint_roundtrips_exactly(self, tmp_path):
+        # transformer and vae both declare hf_subdir="." (SeedVR2's real repo keeps both
+        # files flat at root, told apart on load by weight_files). Saving both to one
+        # directory clobbered the first's shards and index, so the transformer reloaded with
+        # the VAE's weights (#621). This exercises SeedVR2's own weight definition end to end
+        # through ModelSaver -> WeightLoader -> WeightApplier at tiny dimensions.
+        TinyCheckpointRoundtrip.save_and_reload_expecting_identical_weights(
+            weight_definition=SeedVR2WeightDefinition3B,
+            make_components=TestTinySeedVR2ModelSaving._tiny_components,
+            base_path=tmp_path / "seedvr2_tiny_q8",
+            bits=8,
+        )
+
+    @staticmethod
+    def _tiny_components():
+        # vid_in_channels=16 (not the default 33) so PatchIn's proj is Linear(16*1*2*2=64, dim),
+        # a multiple of 64 that SeedVR2's predicate quantizes. vid_dim=64 with one 64-wide head
+        # keeps every attention Linear a multiple of 64. VAE block_out_channels=(64, 64) satisfies
+        # both its GroupNorm(32) and the 64 quantization stride.
+        return {
+            "transformer": SeedVR2Transformer(
+                vid_in_channels=16,
+                vid_dim=64,
+                txt_in_dim=64,
+                heads=1,
+                head_dim=64,
+                num_layers=2,
+                mm_layers=1,
+            ),
+            "vae": SeedVR2VAE(block_out_channels=(64, 64), latent_channels=16),
+        }


### PR DESCRIPTION
## What

`ModelSaver` corrupts a saved checkpoint when two independent components share an `hf_subdir`. SeedVR2's `transformer` and `vae` both declare `hf_subdir="."`, which is right for loading the real repo, where `weight_files` tells them apart. On save, `_save_weights` ignores `weight_files` and writes each component's shards as `0.safetensors`, `1.safetensors`, ... plus `model.safetensors.index.json`, so saving the second component overwrites the first's shards and index. Reloading then hands each component the other's weights.

The fix gives each independent component that shares an `hf_subdir` its own `<hf_subdir>/<name>` directory, used by both the saver and the mflux-format reload probe. The HuggingFace fallback still reads `hf_subdir`, so loading a real (never-mflux-saved) repo is unchanged. Components that split one shared source by prefix, like FIBO VLM's decoder and visual, keep sharing their directory, and every model with unique subdirs is untouched. A scan of all weight definitions confirms only SeedVR2 is affected.

The bug is latent today, since no SeedVR2 save path is wired up, so this changes nothing users can currently trigger and guards the collision for whenever SeedVR2 save support lands.

Fixes #621.

## Verification

Two tests, both no-weights and in the default selector, saving and reloading through the real ModelSaver, WeightLoader and WeightApplier and asserting each component's parameter tree survives byte for byte. `test_tiny_model_saving_seedvr2.py` builds real SeedVR2 transformer and VAE classes at tiny dimensions, the case the bug is about. `test_model_saver_shared_subdir.py` is a minimal two-component stand-in that isolates the same collision. Both are red without the fix, where the transformer reloads with the VAE's weights, and green with it.

Fast model-saving suite 154 passed, weight-loading and resolution 226 passed, ruff clean on the tree.

## Release note

```release-note
none
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed checkpoint saving and loading for models whose components share a source directory.
  - Ensured components are stored and restored from distinct locations when needed.
  - Prevented component files from overwriting one another in shared model layouts.
  - Added validation to report conflicting save locations instead of silently overwriting files.
  - Preserved compatibility with existing model formats and layouts.

- **Tests**
  - Added coverage for shared-directory and quantized checkpoint round trips, including exact weight preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents independently saved components with the same Hugging Face source directory from overwriting one another and aligns mflux-format reload probing with the new save layout.
- Adds deterministic per-component save directories for independent shared-subdirectory components.
- Preserves shared-source prefix-filtered layouts and the original Hugging Face fallback paths.
- Adds generic and SeedVR2-specific quantized checkpoint round-trip coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with saver and loader directory selection aligned and focused round-trip coverage for the affected layout.

Independent components sharing an hf_subdir are assigned matching noncolliding save and reload paths, while existing source-checkpoint fallback behavior and intentional prefix-filtered sharing remain intact.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mflux/models/common/weights/loading/weight_definition.py | Centralizes save-directory selection while preserving intentional prefix-filtered shared-source layouts. |
| src/mflux/models/common/weights/loading/weight_loader.py | Probes the computed component save directory for mflux checkpoints while retaining the original Hugging Face fallback. |
| src/mflux/models/common/weights/saving/model_saver.py | Writes independently saved shared-subdirectory components into distinct directories to prevent shard and index replacement. |
| tests/model_saving/test_model_saver_shared_subdir.py | Verifies an isolated quantized two-component shared-directory checkpoint round trip. |
| tests/model_saving/test_tiny_model_saving_seedvr2.py | Exercises the corrected layout through real tiny SeedVR2 transformer and VAE components. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  D[Component definitions] --> S[Compute save subdirectories]
  S -->|Unique source directory| H[Use hf_subdir]
  S -->|Shared and independent| N[Use hf_subdir/name]
  S -->|Shared prefix-filtered source| H
  N --> W[Save mflux shards and index]
  H --> W
  W --> L[Reload model]
  L --> P[Probe computed mflux save directory]
  P -->|Not found| F[Fall back to original Hugging Face directory]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: independent components sharing an h..."](https://github.com/mflux-community/mflux/commit/413e1e12100d71436a591d7684b1bcca05c64676) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60980886)</sub>

**Context used:**

- Knowledge Base — [Model loading and adaptation](https://app.greptile.com/mflux-community/-/custom-context/knowledge-base/mflux-community/mflux/-/docs/model-loading-and-adaptation.md)

<!-- /greptile_comment -->